### PR TITLE
Removed cmake fail if cpplint not installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -397,9 +397,11 @@ endif (BUILD_TESTS)
 # --------------------------------- cpplint --------------------------------- #
 
 include(cmake/cpplint.cmake)
-cpplint_add_subdirectory(src)
-cpplint_add_subdirectory(include)
-cpplint_add_subdirectory(bindings)
+if (CPPLINT)
+    cpplint_add_subdirectory(src)
+    cpplint_add_subdirectory(include)
+    cpplint_add_subdirectory(bindings)
+endif (CPPLINT)
 
 
 # ------------------------- Reference documentation ------------------------- #

--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ The library is written in C++. For portability a range of C wrappers are provide
 This is a big item on the TODO list - the functional tests in the _test_ directory provide some timing and performance information. An automated test executable to generate the metrics and associated documentation is needed. I have Proxmox Epyc and Xeon servers available that may be configured with suitable OS and hardware settings in a VM to provide repeatable test results.
 
 
+## Static Analysis
+
+Support for _Cpplint_ is provided if the cmake project detects the presence of of the _Cpplint_ parser. If so, static analysis of the source code can be conveniently performed using the target _cpplint_, for example:
+
+```
+_make cpplint_
+```
+
 ## Reference Manual
 
 Documentation for developers describing the library software is contained in the reference manual _<build directory>/docs/phantom_reference.pdf_. This document is built using Doxygen using the _make_doc_ target within your build directory, Doxygen will also produce an html version of the reference manual.

--- a/cmake/cpplint.cmake
+++ b/cmake/cpplint.cmake
@@ -64,65 +64,68 @@ find_file(CPPLINT cpplint)
 if(CPPLINT)
     message(STATUS "cpplint parser: ${CPPLINT}")
 else()
-    message(FATAL_ERROR "cpplint script: NOT FOUND! "
-                        "Please install cpplint as described on https://pypi.python.org/pypi/cpplint. "
-			"In most cases command 'sudo pip install cpplint' should be sufficent.")
+    message(STATUS "cpplint script: NOT FOUND! "
+                   "Please install cpplint as described on https://pypi.python.org/pypi/cpplint. "
+			       "In most cases command 'sudo pip install cpplint' should be sufficent.")
 endif()
 
+if(CPPLINT)
 
-# common target to concatenate all cpplint.py targets
-add_custom_target(${CPPLINT_TARGET})
+    # common target to concatenate all cpplint.py targets
+    add_custom_target(${CPPLINT_TARGET})
 
 
-# use cpplint.py to check source code files inside DIR directory
-function(cpplint_add_subdirectory DIR)
-    # create relative path to the directory
-    set(ABSOLUTE_DIR ${CMAKE_CURRENT_LIST_DIR}/${DIR})
+    # use cpplint.py to check source code files inside DIR directory
+    function(cpplint_add_subdirectory DIR)
+        # create relative path to the directory
+        set(ABSOLUTE_DIR ${CMAKE_CURRENT_LIST_DIR}/${DIR})
 
-    # add *.c files
-    if(CPPLINT_TEST_C_FILES)
-        set(EXTENSIONS       ${EXTENSIONS}c,)
-        set(FILES_TO_CHECK   ${FILES_TO_CHECK} ${ABSOLUTE_DIR}/*.c)
-    endif()
+        # add *.c files
+        if(CPPLINT_TEST_C_FILES)
+            set(EXTENSIONS       ${EXTENSIONS}c,)
+            set(FILES_TO_CHECK   ${FILES_TO_CHECK} ${ABSOLUTE_DIR}/*.c)
+        endif()
 
-    # add *.h files
-    if(CPPLINT_TEST_H_FILES)
-        set(EXTENSIONS       ${EXTENSIONS}h,)
-        set(FILES_TO_CHECK   ${FILES_TO_CHECK} ${ABSOLUTE_DIR}/*.h)
-    endif()
+        # add *.h files
+        if(CPPLINT_TEST_H_FILES)
+            set(EXTENSIONS       ${EXTENSIONS}h,)
+            set(FILES_TO_CHECK   ${FILES_TO_CHECK} ${ABSOLUTE_DIR}/*.h)
+        endif()
 
-    # add *.cpp files
-    if(CPPLINT_TEST_CPP_FILES)
-        set(EXTENSIONS       ${EXTENSIONS}cpp,)
-        set(FILES_TO_CHECK   ${FILES_TO_CHECK} ${ABSOLUTE_DIR}/*.cpp)
-    endif()
+        # add *.cpp files
+        if(CPPLINT_TEST_CPP_FILES)
+            set(EXTENSIONS       ${EXTENSIONS}cpp,)
+            set(FILES_TO_CHECK   ${FILES_TO_CHECK} ${ABSOLUTE_DIR}/*.cpp)
+        endif()
 
-    # add *.hpp files
-    if(CPPLINT_TEST_HPP_FILES)
-        set(EXTENSIONS       ${EXTENSIONS}hpp,)
-        set(FILES_TO_CHECK   ${FILES_TO_CHECK} ${ABSOLUTE_DIR}/*.hpp)
-    endif()
-  
-    # find all source files inside project
-    file(GLOB_RECURSE LIST_OF_FILES ${FILES_TO_CHECK})
-
-    # create valid target name for this check
-    string(REGEX REPLACE "/" "." TEST_NAME ${DIR})
-    set(TARGET_NAME ${CPPLINT_TARGET}.${TEST_NAME})
-
-    # perform cpplint check
-    add_custom_target(${TARGET_NAME}
-        COMMAND ${CPPLINT} "--extensions=${EXTENSIONS}"
-                           "--root=${CPPLINT_PROJECT_ROOT}"
-                           "--quiet"
-                           ${LIST_OF_FILES}
-        DEPENDS ${LIST_OF_FILES}
-        COMMENT "cpplint: Checking source code style"
-    )
-
-    # run this target when root cpplint.py test is triggered
-    add_dependencies(${CPPLINT_TARGET} ${TARGET_NAME})
+        # add *.hpp files
+        if(CPPLINT_TEST_HPP_FILES)
+            set(EXTENSIONS       ${EXTENSIONS}hpp,)
+            set(FILES_TO_CHECK   ${FILES_TO_CHECK} ${ABSOLUTE_DIR}/*.hpp)
+        endif()
     
-    # add this test to CTest
-    #add_test(${TARGET_NAME} ${CMAKE_MAKE_PROGRAM} ${TARGET_NAME})
-endfunction()
+        # find all source files inside project
+        file(GLOB_RECURSE LIST_OF_FILES ${FILES_TO_CHECK})
+
+        # create valid target name for this check
+        string(REGEX REPLACE "/" "." TEST_NAME ${DIR})
+        set(TARGET_NAME ${CPPLINT_TARGET}.${TEST_NAME})
+
+        # perform cpplint check
+        add_custom_target(${TARGET_NAME}
+            COMMAND ${CPPLINT} "--extensions=${EXTENSIONS}"
+                            "--root=${CPPLINT_PROJECT_ROOT}"
+                            "--quiet"
+                            ${LIST_OF_FILES}
+            DEPENDS ${LIST_OF_FILES}
+            COMMENT "cpplint: Checking source code style"
+        )
+
+        # run this target when root cpplint.py test is triggered
+        add_dependencies(${CPPLINT_TARGET} ${TARGET_NAME})
+        
+        # add this test to CTest
+        #add_test(${TARGET_NAME} ${CMAKE_MAKE_PROGRAM} ${TARGET_NAME})
+    endfunction()
+
+endif()


### PR DESCRIPTION
Cpplint no longer causes CMake to fail, instead the _cpplint_ target will no longer be available.

Closes #1 