### PR TITLE
m-ary and NAF exponent recoding for RSA

### DIFF
--- a/include/phantom.hpp
+++ b/include/phantom.hpp
@@ -74,11 +74,13 @@ public:
 
     /// Create a context for the pkc instance based on the required security strength
     std::unique_ptr<user_ctx> create_ctx(security_strength_e strength,
-                                         cpu_word_size_e size_hint = NATIVE_CPU_WORD_SIZE) const;
+                                         cpu_word_size_e size_hint = NATIVE_CPU_WORD_SIZE,
+                                         bool masking = true) const;
 
     /// Create a context for the pkc instance based on a specific parameter set
     std::unique_ptr<user_ctx> create_ctx(size_t set,
-                                         cpu_word_size_e size_hint = NATIVE_CPU_WORD_SIZE) const;
+                                         cpu_word_size_e size_hint = NATIVE_CPU_WORD_SIZE,
+                                         bool masking = true) const;
 
     /// @brief Key generation - creates a public/private key pair
     /// @param ctx The user context containing the key

--- a/src/core/bit_manipulation.hpp
+++ b/src/core/bit_manipulation.hpp
@@ -120,7 +120,7 @@ public:
 
     /// Swap two operands using no additional variables
     template<typename T>
-    static void swap(T x, T y)  // NOLINT
+    static void swap(T &x, T &y)  // NOLINT
     {
         x ^= y;
         y ^= x;

--- a/src/core/mpbase_jacobi.cpp
+++ b/src/core/mpbase_jacobi.cpp
@@ -1089,7 +1089,7 @@ public:
         else {
             if (an > bn) {
                 swap_ptrs<T>(a_limbs, b_limbs);
-                bit_manipulation::swap<T>(an, bn);
+                bit_manipulation::swap<size_t>(an, bn);
                 swapped ^= 1;
             }
         }
@@ -1139,7 +1139,7 @@ public:
 
             if (an > bn) {
                 swap_ptrs<T>(a_limbs, b_limbs);
-                bit_manipulation::swap<T>(an, bn);
+                bit_manipulation::swap<size_t>(an, bn);
                 swapped ^= 1;
             }
         }

--- a/src/core/scalar_parser.cpp
+++ b/src/core/scalar_parser.cpp
@@ -109,10 +109,6 @@ size_t scalar_parser::binary_dual(phantom_vector<uint8_t>& recoded, const phanto
 
     recoded = phantom_vector<uint8_t>(num_codes);
 
-    std::cerr << "!!! binary_dual secret = "
-              << mpz<uint8_t>(const_cast<uint8_t*>(secret.data()), secret.size()).get_str(16)
-              << std::endl;
-
     for (size_t i=0; i < secret.size() * 8 - num_codes; i++) {
         recoded[i] = (secret[(i>>3)] >> (i & 0x7)) & 1;
         std::cerr << " " << static_cast<int>(recoded[i]);

--- a/src/core/scalar_parser.cpp
+++ b/src/core/scalar_parser.cpp
@@ -48,19 +48,19 @@ scalar_parser::scalar_parser(scalar_coding_e coding, const phantom_vector<uint8_
     }
 
     // Recoding of the secret value to non-adjacent form
-    if (scalar_coding_e::ECC_NAF_2 <= coding && scalar_coding_e::ECC_NAF_7 >= coding) {
+    if (scalar_coding_e::SCALAR_NAF_2 <= coding && scalar_coding_e::SCALAR_NAF_7 >= coding) {
         m_recoded = phantom_vector<uint8_t>();
         m_max     = naf(m_recoded, e, static_cast<size_t>(coding) ^ SCALAR_CODING_NAF_BIT);
     }
-    else if (scalar_coding_e::ECC_PRE_2 <= coding && scalar_coding_e::ECC_PRE_8 >= coding) {
+    else if (scalar_coding_e::SCALAR_PRE_2 <= coding && scalar_coding_e::SCALAR_PRE_8 >= coding) {
         m_recoded = phantom_vector<uint8_t>();
         m_max     = window(m_recoded, secret, static_cast<size_t>(coding) ^ SCALAR_CODING_PRE_BIT);
     }
-    else if (scalar_coding_e::ECC_BINARY_DUAL == coding) {
+    else if (scalar_coding_e::SCALAR_BINARY_DUAL == coding) {
         m_recoded = phantom_vector<uint8_t>();
         m_max     = binary_dual(m_recoded, secret);
     }
-    else if (scalar_coding_e::ECC_BINARY == coding || scalar_coding_e::ECC_MONT_LADDER == coding) {
+    else if (scalar_coding_e::SCALAR_BINARY == coding || scalar_coding_e::SCALAR_MONT_LADDER == coding) {
         m_max     = 8*(n - 1) + 8 - bit_manipulation::clz(secret[n - 1]);
         m_recoded = phantom_vector<uint8_t>(secret.begin(), secret.begin() + n);
     }
@@ -72,10 +72,10 @@ scalar_parser::scalar_parser(scalar_coding_e coding, const phantom_vector<uint8_
     m_shift   = ((max_scale * m_max & 7) - 1) & (7 ^ is_naf);
     m_coding  = coding;
 
-    if (scalar_coding_e::ECC_BINARY == coding || scalar_coding_e::ECC_MONT_LADDER == coding ||
-        (scalar_coding_e::ECC_NAF_2 <= coding && scalar_coding_e::ECC_NAF_7 >= coding) ||
-        (scalar_coding_e::ECC_BINARY_DUAL == coding) ||
-        (scalar_coding_e::ECC_PRE_2 <= coding && scalar_coding_e::ECC_PRE_8 >= coding)) {
+    if (scalar_coding_e::SCALAR_BINARY == coding || scalar_coding_e::SCALAR_MONT_LADDER == coding ||
+        (scalar_coding_e::SCALAR_NAF_2 <= coding && scalar_coding_e::SCALAR_NAF_7 >= coding) ||
+        (scalar_coding_e::SCALAR_BINARY_DUAL == coding) ||
+        (scalar_coding_e::SCALAR_PRE_2 <= coding && scalar_coding_e::SCALAR_PRE_8 >= coding)) {
         // Skim through the scalar value until the first bit/window to be pulled by the user will be non-zero
         while (m_max && m_index >= 0 && SCALAR_IS_LOW == peek()) {
             m_max--;
@@ -180,16 +180,16 @@ size_t scalar_parser::naf(phantom_vector<uint8_t>& recoded, const mpz<uint32_t>&
 uint16_t scalar_parser::peek() const
 {
     // Peek ahead at the bit(s) to be pulled depending upon the coding mode
-    if (scalar_coding_e::ECC_BINARY == m_coding || scalar_coding_e::ECC_MONT_LADDER == m_coding) {
+    if (scalar_coding_e::SCALAR_BINARY == m_coding || scalar_coding_e::SCALAR_MONT_LADDER == m_coding) {
         uint16_t word = m_secret1[m_index];
         uint16_t shift = m_shift;
         return (word >> shift) & 0x1;
     }
-    else if (scalar_coding_e::ECC_BINARY_DUAL == m_coding) {
+    else if (scalar_coding_e::SCALAR_BINARY_DUAL == m_coding) {
         uint16_t word = m_recoded[m_index];
         return (word == 0)? SCALAR_IS_LOW : word;
     }
-    else if (scalar_coding_e::ECC_PRE_2 <= m_coding && scalar_coding_e::ECC_PRE_8 >= m_coding) {
+    else if (scalar_coding_e::SCALAR_PRE_2 <= m_coding && scalar_coding_e::SCALAR_PRE_8 >= m_coding) {
         uint16_t word = m_recoded[m_index];
         return (word == 0)? SCALAR_IS_LOW : word;
     }
@@ -271,13 +271,13 @@ uint32_t scalar_parser::pull()
     uint16_t word, shift;
 
     // Obtain the bit depending upon the coding mode
-    if (scalar_coding_e::ECC_BINARY == m_coding || scalar_coding_e::ECC_MONT_LADDER == m_coding) {
+    if (scalar_coding_e::SCALAR_BINARY == m_coding || scalar_coding_e::SCALAR_MONT_LADDER == m_coding) {
         bit = pull_binary();
     }
-    else if (scalar_coding_e::ECC_BINARY_DUAL == m_coding) {
+    else if (scalar_coding_e::SCALAR_BINARY_DUAL == m_coding) {
         bit = pull_binary_dual();
     }
-    else if (scalar_coding_e::ECC_PRE_2 <= m_coding && scalar_coding_e::ECC_PRE_8 >= m_coding) {
+    else if (scalar_coding_e::SCALAR_PRE_2 <= m_coding && scalar_coding_e::SCALAR_PRE_8 >= m_coding) {
         bit = pull_window();
     }
     else {

--- a/src/core/scalar_parser.hpp
+++ b/src/core/scalar_parser.hpp
@@ -38,22 +38,22 @@ namespace core {
 
 /// An enumerated type describing the coding of scalar numbers
 enum scalar_coding_e {
-    ECC_BINARY           = 0,
-    ECC_MONT_LADDER      = 1,
-    ECC_PRE_2            = SCALAR_CODING_PRE_BIT + 2,
-    ECC_PRE_3            = SCALAR_CODING_PRE_BIT + 3,
-    ECC_PRE_4            = SCALAR_CODING_PRE_BIT + 4,
-    ECC_PRE_5            = SCALAR_CODING_PRE_BIT + 5,
-    ECC_PRE_6            = SCALAR_CODING_PRE_BIT + 6,
-    ECC_PRE_7            = SCALAR_CODING_PRE_BIT + 7,
-    ECC_PRE_8            = SCALAR_CODING_PRE_BIT + 8,
-    ECC_NAF_2            = SCALAR_CODING_NAF_BIT + 2,
-    ECC_NAF_3            = SCALAR_CODING_NAF_BIT + 3,
-    ECC_NAF_4            = SCALAR_CODING_NAF_BIT + 4,
-    ECC_NAF_5            = SCALAR_CODING_NAF_BIT + 5,
-    ECC_NAF_6            = SCALAR_CODING_NAF_BIT + 6,
-    ECC_NAF_7            = SCALAR_CODING_NAF_BIT + 7,
-    ECC_BINARY_DUAL      = SCALAR_CODING_BINARY_DUAL + 2,
+    SCALAR_BINARY           = 0,
+    SCALAR_MONT_LADDER      = 1,
+    SCALAR_PRE_2            = SCALAR_CODING_PRE_BIT + 2,
+    SCALAR_PRE_3            = SCALAR_CODING_PRE_BIT + 3,
+    SCALAR_PRE_4            = SCALAR_CODING_PRE_BIT + 4,
+    SCALAR_PRE_5            = SCALAR_CODING_PRE_BIT + 5,
+    SCALAR_PRE_6            = SCALAR_CODING_PRE_BIT + 6,
+    SCALAR_PRE_7            = SCALAR_CODING_PRE_BIT + 7,
+    SCALAR_PRE_8            = SCALAR_CODING_PRE_BIT + 8,
+    SCALAR_NAF_2            = SCALAR_CODING_NAF_BIT + 2,
+    SCALAR_NAF_3            = SCALAR_CODING_NAF_BIT + 3,
+    SCALAR_NAF_4            = SCALAR_CODING_NAF_BIT + 4,
+    SCALAR_NAF_5            = SCALAR_CODING_NAF_BIT + 5,
+    SCALAR_NAF_6            = SCALAR_CODING_NAF_BIT + 6,
+    SCALAR_NAF_7            = SCALAR_CODING_NAF_BIT + 7,
+    SCALAR_BINARY_DUAL      = SCALAR_CODING_BINARY_DUAL + 2,
 };
 
 /** 

--- a/src/ecc/ecc.hpp
+++ b/src/ecc/ecc.hpp
@@ -332,7 +332,6 @@ public:
         core::scalar_parser bitgen(m_coding_type, secret);
         size_t num_bits = bitgen.num_symbols();
         if (0 == num_bits) {
-            std::cerr << "!!! SECRET_IS_ZERO" << std::endl;
             return SECRET_IS_ZERO;
         }
 
@@ -340,7 +339,6 @@ public:
         num_bits--;
         uint32_t bit = bitgen.pull();
         if (SCALAR_IS_LOW == bit) {
-            std::cerr << "!!! RECODING_ERROR" << std::endl;
             return RECODING_ERROR;
         }
 
@@ -353,19 +351,16 @@ public:
         retcode_e retcode;
         if (core::SCALAR_MONT_LADDER == m_coding_type) {
             if (POINT_OK != (retcode = montgomery_ladder(bitgen, num_bits, w, bit, sub_offset))) {
-                std::cerr << "!!! montgomery_ladder() failed" << std::endl;
                 return retcode;
             }
         }
         else if (m_masking) {
             if (POINT_OK != (retcode = double_and_add(bitgen, num_bits, w, bit, sub_offset))) {
-                std::cerr << "!!! double_and_add() failed" << std::endl;
                 return retcode;
             }
         }
         else {
             if (POINT_OK != (retcode = double_and_add_unmasked(bitgen, num_bits, w, bit, sub_offset))) {
-                std::cerr << "!!! double_and_add_unmasked() failed" << std::endl;
                 return retcode;
             }
         }

--- a/src/ecc/ecc.hpp
+++ b/src/ecc/ecc.hpp
@@ -58,18 +58,18 @@ class ecc
 
         switch (m_coding_type)
         {
-            case core::scalar_coding_e::ECC_BINARY_DUAL:
+            case core::scalar_coding_e::SCALAR_BINARY_DUAL:
             {
                 m_point_pre[1] = std::unique_ptr<point<T>>(new P<T>(m_config));
                 m_point_pre[2] = std::unique_ptr<point<T>>(new P<T>(m_config));
             } break;
 
-            case core::scalar_coding_e::ECC_NAF_2:
-            case core::scalar_coding_e::ECC_NAF_3:
-            case core::scalar_coding_e::ECC_NAF_4:
-            case core::scalar_coding_e::ECC_NAF_5:
-            case core::scalar_coding_e::ECC_NAF_6:
-            case core::scalar_coding_e::ECC_NAF_7:
+            case core::scalar_coding_e::SCALAR_NAF_2:
+            case core::scalar_coding_e::SCALAR_NAF_3:
+            case core::scalar_coding_e::SCALAR_NAF_4:
+            case core::scalar_coding_e::SCALAR_NAF_5:
+            case core::scalar_coding_e::SCALAR_NAF_6:
+            case core::scalar_coding_e::SCALAR_NAF_7:
             {
                 size_t w = (1 << ((static_cast<size_t>(m_coding_type) ^ SCALAR_CODING_NAF_BIT) - 1)) - 1;
 
@@ -78,13 +78,13 @@ class ecc
                 }
             } break;
 
-            case core::scalar_coding_e::ECC_PRE_2:
-            case core::scalar_coding_e::ECC_PRE_3:
-            case core::scalar_coding_e::ECC_PRE_4:
-            case core::scalar_coding_e::ECC_PRE_5:
-            case core::scalar_coding_e::ECC_PRE_6:
-            case core::scalar_coding_e::ECC_PRE_7:
-            case core::scalar_coding_e::ECC_PRE_8:
+            case core::scalar_coding_e::SCALAR_PRE_2:
+            case core::scalar_coding_e::SCALAR_PRE_3:
+            case core::scalar_coding_e::SCALAR_PRE_4:
+            case core::scalar_coding_e::SCALAR_PRE_5:
+            case core::scalar_coding_e::SCALAR_PRE_6:
+            case core::scalar_coding_e::SCALAR_PRE_7:
+            case core::scalar_coding_e::SCALAR_PRE_8:
             {
                 size_t w = (1 << (static_cast<size_t>(m_coding_type) ^ SCALAR_CODING_PRE_BIT));
 
@@ -113,13 +113,13 @@ public:
      * @param cfg AN ecc_config object defining how ECC is configured
      * @param field The type of field to be used (default: WEIERSTRASS_PRIME_FIELD)
      * @param coord_type The coordinate system to be used (default: POINT_COORD_AFFINE)
-     * @param coding The scalar coding method to be used (default: ECC_BINARY)
+     * @param coding The scalar coding method to be used (default: SCALAR_BINARY)
      * @param masking A flag to indicate if double-and-add masking is required (default: true)
      */
     ecc(const ecc_config<T>& cfg,
         field_e field = WEIERSTRASS_PRIME_FIELD,
         type_e coord_type = POINT_COORD_AFFINE,
-        core::scalar_coding_e coding = core::scalar_coding_e::ECC_BINARY,
+        core::scalar_coding_e coding = core::scalar_coding_e::SCALAR_BINARY,
         bool masking = true) :
         m_config(cfg),
         m_field(field),
@@ -249,7 +249,7 @@ public:
 
         switch (m_coding_type)
         {
-            case core::scalar_coding_e::ECC_BINARY_DUAL:
+            case core::scalar_coding_e::SCALAR_BINARY_DUAL:
             {
                 m_point_pre[2]->copy(*m_point_pre[0].get());
                 if (POINT_OK != m_point_pre[2]->addition(m_config, *m_point_pre[1].get())) {
@@ -257,12 +257,12 @@ public:
                 }
             } break;
 
-            case core::scalar_coding_e::ECC_NAF_2:
-            case core::scalar_coding_e::ECC_NAF_3:
-            case core::scalar_coding_e::ECC_NAF_4:
-            case core::scalar_coding_e::ECC_NAF_5:
-            case core::scalar_coding_e::ECC_NAF_6:
-            case core::scalar_coding_e::ECC_NAF_7:
+            case core::scalar_coding_e::SCALAR_NAF_2:
+            case core::scalar_coding_e::SCALAR_NAF_3:
+            case core::scalar_coding_e::SCALAR_NAF_4:
+            case core::scalar_coding_e::SCALAR_NAF_5:
+            case core::scalar_coding_e::SCALAR_NAF_6:
+            case core::scalar_coding_e::SCALAR_NAF_7:
             {
                 size_t w = static_cast<size_t>(m_coding_type) ^ SCALAR_CODING_NAF_BIT;
                 size_t r = (1 << (w - 1)) - 1;
@@ -282,13 +282,13 @@ public:
                 // Converting to mixed is too expensive
             } break;
 
-            case core::scalar_coding_e::ECC_PRE_2:
-            case core::scalar_coding_e::ECC_PRE_3:
-            case core::scalar_coding_e::ECC_PRE_4:
-            case core::scalar_coding_e::ECC_PRE_5:
-            case core::scalar_coding_e::ECC_PRE_6:
-            case core::scalar_coding_e::ECC_PRE_7:
-            case core::scalar_coding_e::ECC_PRE_8:
+            case core::scalar_coding_e::SCALAR_PRE_2:
+            case core::scalar_coding_e::SCALAR_PRE_3:
+            case core::scalar_coding_e::SCALAR_PRE_4:
+            case core::scalar_coding_e::SCALAR_PRE_5:
+            case core::scalar_coding_e::SCALAR_PRE_6:
+            case core::scalar_coding_e::SCALAR_PRE_7:
+            case core::scalar_coding_e::SCALAR_PRE_8:
             {
                 size_t w = static_cast<size_t>(m_coding_type) ^ SCALAR_CODING_PRE_BIT;
                 size_t r = 1 << w;
@@ -345,12 +345,12 @@ public:
         }
 
         size_t sub_offset = 0;
-        if (core::scalar_coding_e::ECC_NAF_2 <= m_coding_type && core::scalar_coding_e::ECC_NAF_7 >= m_coding_type) {
+        if (core::scalar_coding_e::SCALAR_NAF_2 <= m_coding_type && core::scalar_coding_e::SCALAR_NAF_7 >= m_coding_type) {
             sub_offset = (1 << ((static_cast<size_t>(m_coding_type) & 0x3f) - 1)) - 2;
         }
 
         retcode_e retcode;
-        if (core::ECC_MONT_LADDER == m_coding_type) {
+        if (core::SCALAR_MONT_LADDER == m_coding_type) {
             if (POINT_OK != (retcode = montgomery_ladder(bitgen, num_bits, w, bit, sub_offset))) {
                 std::cerr << "!!! montgomery_ladder() failed" << std::endl;
                 return retcode;

--- a/src/ecc/ecc.hpp
+++ b/src/ecc/ecc.hpp
@@ -345,7 +345,8 @@ public:
         }
 
         size_t sub_offset = 0;
-        if (core::scalar_coding_e::SCALAR_NAF_2 <= m_coding_type && core::scalar_coding_e::SCALAR_NAF_7 >= m_coding_type) {
+        if (core::scalar_coding_e::SCALAR_NAF_2 <= m_coding_type &&
+            core::scalar_coding_e::SCALAR_NAF_7 >= m_coding_type) {
             sub_offset = (1 << ((static_cast<size_t>(m_coding_type) & 0x3f) - 1)) - 2;
         }
 

--- a/src/phantom.cpp
+++ b/src/phantom.cpp
@@ -183,14 +183,18 @@ pkc::~pkc()
 {
 }
 
-std::unique_ptr<user_ctx> pkc::create_ctx(security_strength_e strength, cpu_word_size_e size_hint) const
+std::unique_ptr<user_ctx> pkc::create_ctx(security_strength_e strength,
+                                          cpu_word_size_e size_hint,
+                                          bool masking) const
 {
-    return m_scheme->create_ctx(strength, size_hint);
+    return m_scheme->create_ctx(strength, size_hint, masking);
 }
 
-std::unique_ptr<user_ctx> pkc::create_ctx(size_t set, cpu_word_size_e size_hint) const
+std::unique_ptr<user_ctx> pkc::create_ctx(size_t set,
+                                          cpu_word_size_e size_hint,
+                                          bool masking) const
 {
-    return m_scheme->create_ctx(set, size_hint);
+    return m_scheme->create_ctx(set, size_hint, masking);
 }
 
 bool pkc::keygen(std::unique_ptr<user_ctx>& ctx)

--- a/src/rsa/ctx_rsa.hpp
+++ b/src/rsa/ctx_rsa.hpp
@@ -54,10 +54,10 @@ template<class T>
 class ctx_rsa_tmpl : public ctx_rsa
 {
 public:
-    explicit ctx_rsa_tmpl(size_t set) : m_scheme(PKC_PKE_RSAES_OAEP), m_set(set)
+    ctx_rsa_tmpl(size_t set, bool masking) : m_scheme(PKC_PKE_RSAES_OAEP), m_set(set)
     {
         m_rsa_pke = std::unique_ptr<phantom::rsa::rsa_cryptosystem<T>>(
-            new phantom::rsa::rsa_cryptosystem<T>());
+            new phantom::rsa::rsa_cryptosystem<T>(core::scalar_coding_e::SCALAR_BINARY, masking));
 
         if (!set_hash(static_cast<crypto::hash_alg_e>((set >> 8) & 0x1f))) {
             throw std::runtime_error("Hash is unknown");

--- a/src/rsa/rsa_cryptosystem.hpp
+++ b/src/rsa/rsa_cryptosystem.hpp
@@ -357,7 +357,7 @@ protected:
         e.get_bytes(e_bytes);
 
         // Use the scalar_parser to scan the bit sequence and perform recoding
-        core::scalar_parser bitgen(core::scalar_coding_e::ECC_BINARY, e_bytes);
+        core::scalar_parser bitgen(core::scalar_coding_e::SCALAR_BINARY, e_bytes);
         size_t num_bits = bitgen.num_symbols();
         if (0 == num_bits) {
             std::cout << "num_bits is zero" << std::endl;

--- a/src/schemes/ibe/dlp/ibe_dlp.cpp
+++ b/src/schemes/ibe/dlp/ibe_dlp.cpp
@@ -66,7 +66,9 @@ ibe_dlp::~ibe_dlp()
 {
 }
 
-std::unique_ptr<user_ctx> ibe_dlp::create_ctx(security_strength_e bits, cpu_word_size_e size_hint) const
+std::unique_ptr<user_ctx> ibe_dlp::create_ctx(security_strength_e bits,
+                                              cpu_word_size_e size_hint,
+                                              bool masking) const
 {
     ctx_ibe_dlp* ctx = new ctx_ibe_dlp(ibe_dlp::bits_2_set(bits));
     if (ctx->get_set() > 1) {
@@ -75,7 +77,9 @@ std::unique_ptr<user_ctx> ibe_dlp::create_ctx(security_strength_e bits, cpu_word
     return std::unique_ptr<user_ctx>(ctx);
 }
 
-std::unique_ptr<user_ctx> ibe_dlp::create_ctx(size_t set, cpu_word_size_e size_hint) const
+std::unique_ptr<user_ctx> ibe_dlp::create_ctx(size_t set,
+                                              cpu_word_size_e size_hint,
+                                              bool masking) const
 {
     ctx_ibe_dlp* ctx = new ctx_ibe_dlp(set);
     if (ctx->get_set() > 1) {

--- a/src/schemes/ibe/dlp/ibe_dlp.hpp
+++ b/src/schemes/ibe/dlp/ibe_dlp.hpp
@@ -35,10 +35,15 @@ public:
     virtual ~ibe_dlp();
 
     /// Create a context for the pkc instance based on the required security strength
-    std::unique_ptr<user_ctx> create_ctx(security_strength_e strength, cpu_word_size_e size_hint) const override;
+    std::unique_ptr<user_ctx> create_ctx(security_strength_e bits,
+                                         cpu_word_size_e size_hint,
+                                         bool masking = true) const override;
 
     /// Create a context for the pkc instance based on the parameter set
-    std::unique_ptr<user_ctx> create_ctx(size_t set, cpu_word_size_e size_hint) const override;
+    std::unique_ptr<user_ctx> create_ctx(size_t set,
+                                         cpu_word_size_e size_hint,
+                                         bool masking = true) const override;
+
 
     /// Key manipulation methods
     /// @{

--- a/src/schemes/kem/kyber/kyber_kem.cpp
+++ b/src/schemes/kem/kyber/kyber_kem.cpp
@@ -32,7 +32,9 @@ kyber_kem::~kyber_kem()
 {
 }
 
-std::unique_ptr<user_ctx> kyber_kem::create_ctx(security_strength_e bits, cpu_word_size_e size_hint) const
+std::unique_ptr<user_ctx> kyber_kem::create_ctx(security_strength_e bits,
+                                                cpu_word_size_e size_hint,
+                                                bool masking) const
 {
     ctx_kyber* ctx = new ctx_kyber(kyber_indcpa::bits_2_set(bits));
     if (ctx->get_set() > 2) {
@@ -41,7 +43,9 @@ std::unique_ptr<user_ctx> kyber_kem::create_ctx(security_strength_e bits, cpu_wo
     return std::unique_ptr<user_ctx>(ctx);
 }
 
-std::unique_ptr<user_ctx> kyber_kem::create_ctx(size_t set, cpu_word_size_e size_hint) const
+std::unique_ptr<user_ctx> kyber_kem::create_ctx(size_t set,
+                                                cpu_word_size_e size_hint,
+                                                bool masking) const
 {
     ctx_kyber* ctx = new ctx_kyber(set);
     if (ctx->get_set() > 2) {

--- a/src/schemes/kem/kyber/kyber_kem.hpp
+++ b/src/schemes/kem/kyber/kyber_kem.hpp
@@ -35,11 +35,16 @@ public:
     /// Class destructor
     virtual ~kyber_kem();
 
-    /// Create a context for the pkc instance based on the required security strength
-    std::unique_ptr<user_ctx> create_ctx(security_strength_e strength, cpu_word_size_e size_hint) const override;
+        /// Create a context for the pkc instance based on the required security strength
+    std::unique_ptr<user_ctx> create_ctx(security_strength_e strength,
+                                         cpu_word_size_e size_hint,
+                                         bool masking = true) const override;
 
     /// Create a context for the pkc instance based on the parameter set
-    std::unique_ptr<user_ctx> create_ctx(size_t set, cpu_word_size_e size_hint) const override;
+    std::unique_ptr<user_ctx> create_ctx(size_t set,
+                                         cpu_word_size_e size_hint,
+                                         bool masking = true) const override;
+
 
     /// Key manipulation methods
     /// @{

--- a/src/schemes/kem/saber/saber_kem.cpp
+++ b/src/schemes/kem/saber/saber_kem.cpp
@@ -28,7 +28,9 @@ saber_kem::~saber_kem()
 {
 }
 
-std::unique_ptr<user_ctx> saber_kem::create_ctx(security_strength_e bits, cpu_word_size_e size_hint) const
+std::unique_ptr<user_ctx> saber_kem::create_ctx(security_strength_e bits,
+                                                cpu_word_size_e size_hint,
+                                                bool masking) const
 {
     ctx_saber* ctx = new ctx_saber(saber_indcpa::bits_2_set(bits));
     if (ctx->get_set() > 2) {
@@ -37,7 +39,9 @@ std::unique_ptr<user_ctx> saber_kem::create_ctx(security_strength_e bits, cpu_wo
     return std::unique_ptr<user_ctx>(ctx);
 }
 
-std::unique_ptr<user_ctx> saber_kem::create_ctx(size_t set, cpu_word_size_e size_hint) const
+std::unique_ptr<user_ctx> saber_kem::create_ctx(size_t set,
+                                                cpu_word_size_e size_hint,
+                                                bool masking) const
 {
     ctx_saber* ctx = new ctx_saber(set);
     if (ctx->get_set() > 2) {

--- a/src/schemes/kem/saber/saber_kem.hpp
+++ b/src/schemes/kem/saber/saber_kem.hpp
@@ -37,10 +37,15 @@ public:
     virtual ~saber_kem();
 
     /// Create a context for the pkc instance based on the required security strength
-    std::unique_ptr<user_ctx> create_ctx(security_strength_e strength, cpu_word_size_e size_hint) const override;
+    std::unique_ptr<user_ctx> create_ctx(security_strength_e strength,
+                                         cpu_word_size_e size_hint,
+                                         bool masking = true) const override;
 
     /// Create a context for the pkc instance based on the parameter set
-    std::unique_ptr<user_ctx> create_ctx(size_t set, cpu_word_size_e size_hint) const override;
+    std::unique_ptr<user_ctx> create_ctx(size_t set,
+                                         cpu_word_size_e size_hint,
+                                         bool masking = true) const override;
+
 
     /// Key manipulation methods
     /// @{

--- a/src/schemes/key_exchange/ecdh/ctx_ecdh.hpp
+++ b/src/schemes/key_exchange/ecdh/ctx_ecdh.hpp
@@ -355,12 +355,12 @@ private:
         m_ecdh_init  = std::unique_ptr<elliptic::ecc<T>>(new elliptic::ecc<T>(m_params.cfg,
                                                          m_params.field,
                                                          elliptic::POINT_COORD_JACOBIAN,
-                                                         core::ECC_PRE_8,
+                                                         core::SCALAR_PRE_8,
                                                          true));
         m_ecdh_final = std::unique_ptr<elliptic::ecc<T>>(new elliptic::ecc<T>(m_params.cfg,
                                                          m_params.field,
                                                          elliptic::POINT_COORD_JACOBIAN,
-                                                         core::ECC_PRE_5,
+                                                         core::SCALAR_PRE_5,
                                                          true));
     }
 
@@ -418,12 +418,12 @@ private:
         m_ecdh_init  = std::unique_ptr<elliptic::ecc<T>>(new elliptic::ecc<T>(m_params.cfg,
                                                          m_params.field,
                                                          elliptic::POINT_COORD_PROJECTIVE,
-                                                         core::ECC_MONT_LADDER,
+                                                         core::SCALAR_MONT_LADDER,
                                                          false));
         m_ecdh_final = std::unique_ptr<elliptic::ecc<T>>(new elliptic::ecc<T>(m_params.cfg,
                                                          m_params.field,
                                                          elliptic::POINT_COORD_PROJECTIVE,
-                                                         core::ECC_MONT_LADDER,
+                                                         core::SCALAR_MONT_LADDER,
                                                          false));
     }
 
@@ -450,12 +450,12 @@ private:
         m_ecdh_init  = std::unique_ptr<elliptic::ecc<T>>(new elliptic::ecc<T>(m_params.cfg,
                                                          m_params.field,
                                                          elliptic::POINT_COORD_JACOBIAN,
-                                                         core::ECC_PRE_8,
+                                                         core::SCALAR_PRE_8,
                                                          true));
         m_ecdh_final = std::unique_ptr<elliptic::ecc<T>>(new elliptic::ecc<T>(m_params.cfg,
                                                          m_params.field,
                                                          elliptic::POINT_COORD_JACOBIAN,
-                                                         core::ECC_PRE_5,
+                                                         core::SCALAR_PRE_5,
                                                          true));
     }
 

--- a/src/schemes/key_exchange/ecdh/ecdh_key_exchange.cpp
+++ b/src/schemes/key_exchange/ecdh/ecdh_key_exchange.cpp
@@ -70,7 +70,9 @@ ecdh_key_exchange::~ecdh_key_exchange()
 {
 }
 
-std::unique_ptr<user_ctx> ecdh_key_exchange::create_ctx(security_strength_e bits, cpu_word_size_e size_hint) const
+std::unique_ptr<user_ctx> ecdh_key_exchange::create_ctx(security_strength_e bits,
+                                                        cpu_word_size_e size_hint,
+                                                        bool masking) const
 {
     user_ctx* ctx;
     switch (size_hint)
@@ -90,7 +92,9 @@ std::unique_ptr<user_ctx> ecdh_key_exchange::create_ctx(security_strength_e bits
     return std::unique_ptr<user_ctx>(ctx);
 }
 
-std::unique_ptr<user_ctx> ecdh_key_exchange::create_ctx(size_t set, cpu_word_size_e size_hint) const
+std::unique_ptr<user_ctx> ecdh_key_exchange::create_ctx(size_t set,
+                                                        cpu_word_size_e size_hint,
+                                                        bool masking) const
 {
     user_ctx* ctx;
     switch (size_hint)

--- a/src/schemes/key_exchange/ecdh/ecdh_key_exchange.hpp
+++ b/src/schemes/key_exchange/ecdh/ecdh_key_exchange.hpp
@@ -32,10 +32,14 @@ public:
     virtual ~ecdh_key_exchange();
 
     /// Create a context for the pkc instance based on the required security strength
-    std::unique_ptr<user_ctx> create_ctx(security_strength_e strength, cpu_word_size_e size_hint) const override;
+    std::unique_ptr<user_ctx> create_ctx(security_strength_e strength,
+                                         cpu_word_size_e size_hint,
+                                         bool masking = true) const override;
 
     /// Create a context for the pkc instance based on the parameter set
-    std::unique_ptr<user_ctx> create_ctx(size_t set, cpu_word_size_e size_hint) const override;
+    std::unique_ptr<user_ctx> create_ctx(size_t set,
+                                         cpu_word_size_e size_hint,
+                                         bool masking = true) const override;
 
     /// Key manipulation methods
     /// @{

--- a/src/schemes/pke/kyber/kyber_pke.cpp
+++ b/src/schemes/pke/kyber/kyber_pke.cpp
@@ -30,7 +30,9 @@ kyber_pke::~kyber_pke()
 {
 }
 
-std::unique_ptr<user_ctx> kyber_pke::create_ctx(security_strength_e bits, cpu_word_size_e size_hint) const
+std::unique_ptr<user_ctx> kyber_pke::create_ctx(security_strength_e bits,
+                                                cpu_word_size_e size_hint,
+                                                bool masking) const
 {
     ctx_kyber_pke* ctx = new ctx_kyber_pke(kyber_indcpa::bits_2_set(bits));
     if (ctx->get_set() > 2) {
@@ -39,7 +41,9 @@ std::unique_ptr<user_ctx> kyber_pke::create_ctx(security_strength_e bits, cpu_wo
     return std::unique_ptr<user_ctx>(ctx);
 }
 
-std::unique_ptr<user_ctx> kyber_pke::create_ctx(size_t set, cpu_word_size_e size_hint) const
+std::unique_ptr<user_ctx> kyber_pke::create_ctx(size_t set,
+                                                cpu_word_size_e size_hint,
+                                                bool masking) const
 {
     ctx_kyber_pke* ctx = new ctx_kyber_pke(set);
     if (ctx->get_set() > 2) {

--- a/src/schemes/pke/kyber/kyber_pke.hpp
+++ b/src/schemes/pke/kyber/kyber_pke.hpp
@@ -30,10 +30,15 @@ public:
     virtual ~kyber_pke();
 
     /// Create a context for the pkc instance based on the required security strength
-    std::unique_ptr<user_ctx> create_ctx(security_strength_e strength, cpu_word_size_e size_hint) const override;
+    std::unique_ptr<user_ctx> create_ctx(security_strength_e strength,
+                                         cpu_word_size_e size_hint,
+                                         bool masking = true) const override;
 
     /// Create a context for the pkc instance based on the parameter set
-    std::unique_ptr<user_ctx> create_ctx(size_t set, cpu_word_size_e size_hint) const override;
+    std::unique_ptr<user_ctx> create_ctx(size_t set,
+                                         cpu_word_size_e size_hint,
+                                         bool masking = true) const override;
+
 
     /// Key manipulation methods
     /// @{

--- a/src/schemes/pke/rsaes_oaep/rsaes_oaep_pke.cpp
+++ b/src/schemes/pke/rsaes_oaep/rsaes_oaep_pke.cpp
@@ -75,15 +75,17 @@ rsaes_oaep_pke::~rsaes_oaep_pke()
 {
 }
 
-std::unique_ptr<user_ctx> rsaes_oaep_pke::create_ctx(security_strength_e bits, cpu_word_size_e size_hint) const
+std::unique_ptr<user_ctx> rsaes_oaep_pke::create_ctx(security_strength_e bits,
+                                                     cpu_word_size_e size_hint,
+                                                     bool masking) const
 {
     user_ctx* ctx;
     switch (size_hint)
     {
-        case CPU_WORD_SIZE_16: ctx = new phantom::rsa::ctx_rsa_tmpl<uint16_t>(bits_2_set(bits)); break;
-        case CPU_WORD_SIZE_32: ctx = new phantom::rsa::ctx_rsa_tmpl<uint32_t>(bits_2_set(bits)); break;
+        case CPU_WORD_SIZE_16: ctx = new phantom::rsa::ctx_rsa_tmpl<uint16_t>(bits_2_set(bits), masking); break;
+        case CPU_WORD_SIZE_32: ctx = new phantom::rsa::ctx_rsa_tmpl<uint32_t>(bits_2_set(bits), masking); break;
 #if defined(IS_64BIT)
-        case CPU_WORD_SIZE_64: ctx = new phantom::rsa::ctx_rsa_tmpl<uint64_t>(bits_2_set(bits)); break;
+        case CPU_WORD_SIZE_64: ctx = new phantom::rsa::ctx_rsa_tmpl<uint64_t>(bits_2_set(bits), masking); break;
 #endif
         default: throw std::invalid_argument("size_hint set is out of range");;
     }
@@ -94,15 +96,17 @@ std::unique_ptr<user_ctx> rsaes_oaep_pke::create_ctx(security_strength_e bits, c
     return std::unique_ptr<user_ctx>(ctx);
 }
 
-std::unique_ptr<user_ctx> rsaes_oaep_pke::create_ctx(size_t set, cpu_word_size_e size_hint) const
+std::unique_ptr<user_ctx> rsaes_oaep_pke::create_ctx(size_t set,
+                                                     cpu_word_size_e size_hint,
+                                                     bool masking) const
 {
     user_ctx* ctx;
     switch (size_hint)
     {
-        case CPU_WORD_SIZE_16: ctx = new phantom::rsa::ctx_rsa_tmpl<uint16_t>(set); break;
-        case CPU_WORD_SIZE_32: ctx = new phantom::rsa::ctx_rsa_tmpl<uint32_t>(set); break;
+        case CPU_WORD_SIZE_16: ctx = new phantom::rsa::ctx_rsa_tmpl<uint16_t>(set, masking); break;
+        case CPU_WORD_SIZE_32: ctx = new phantom::rsa::ctx_rsa_tmpl<uint32_t>(set, masking); break;
 #if defined(IS_64BIT)
-        case CPU_WORD_SIZE_64: ctx = new phantom::rsa::ctx_rsa_tmpl<uint64_t>(set); break;
+        case CPU_WORD_SIZE_64: ctx = new phantom::rsa::ctx_rsa_tmpl<uint64_t>(set, masking); break;
 #endif
         default: throw std::invalid_argument("size_hint set is out of range");;
     }

--- a/src/schemes/pke/rsaes_oaep/rsaes_oaep_pke.hpp
+++ b/src/schemes/pke/rsaes_oaep/rsaes_oaep_pke.hpp
@@ -30,10 +30,15 @@ public:
     virtual ~rsaes_oaep_pke();
 
     /// Create a context for the pkc instance based on the required security strength
-    std::unique_ptr<user_ctx> create_ctx(security_strength_e strength, cpu_word_size_e size_hint) const override;
+    std::unique_ptr<user_ctx> create_ctx(security_strength_e strength,
+                                         cpu_word_size_e size_hint,
+                                         bool masking = true) const override;
 
     /// Create a context for the pkc instance based on the parameter set
-    std::unique_ptr<user_ctx> create_ctx(size_t set, cpu_word_size_e size_hint) const override;
+    std::unique_ptr<user_ctx> create_ctx(size_t set,
+                                         cpu_word_size_e size_hint,
+                                         bool masking = true) const override;
+
 
     /// Key manipulation methods
     /// @{

--- a/src/schemes/pke/saber/saber_pke.cpp
+++ b/src/schemes/pke/saber/saber_pke.cpp
@@ -30,7 +30,9 @@ saber_pke::~saber_pke()
 {
 }
 
-std::unique_ptr<user_ctx> saber_pke::create_ctx(security_strength_e bits, cpu_word_size_e size_hint) const
+std::unique_ptr<user_ctx> saber_pke::create_ctx(security_strength_e bits,
+                                                cpu_word_size_e size_hint,
+                                                bool masking) const
 {
     ctx_saber_pke* ctx = new ctx_saber_pke(saber_indcpa::bits_2_set(bits));
     if (ctx->get_set() > 2) {
@@ -39,7 +41,9 @@ std::unique_ptr<user_ctx> saber_pke::create_ctx(security_strength_e bits, cpu_wo
     return std::unique_ptr<user_ctx>(ctx);
 }
 
-std::unique_ptr<user_ctx> saber_pke::create_ctx(size_t set, cpu_word_size_e size_hint) const
+std::unique_ptr<user_ctx> saber_pke::create_ctx(size_t set,
+                                                cpu_word_size_e size_hint,
+                                                bool masking) const
 {
     ctx_saber_pke* ctx = new ctx_saber_pke(set);
     if (ctx->get_set() > 2) {

--- a/src/schemes/pke/saber/saber_pke.hpp
+++ b/src/schemes/pke/saber/saber_pke.hpp
@@ -31,11 +31,14 @@ public:
 
     /// Create a context for the pkc instance based on the required security strength
     std::unique_ptr<user_ctx> create_ctx(security_strength_e strength,
-                                         cpu_word_size_e size_hint) const override;
+                                         cpu_word_size_e size_hint,
+                                         bool masking = true) const override;
 
     /// Create a context for the pkc instance based on the parameter set
     std::unique_ptr<user_ctx> create_ctx(size_t set,
-                                         cpu_word_size_e size_hint) const override;
+                                         cpu_word_size_e size_hint,
+                                         bool masking = true) const override;
+
 
     /// Key manipulation methods
     /// @{

--- a/src/schemes/scheme.hpp
+++ b/src/schemes/scheme.hpp
@@ -26,10 +26,14 @@ public:
     virtual ~scheme() {}
 
     /// Create a context for the pkc instance based on the required security strength
-    virtual std::unique_ptr<user_ctx> create_ctx(security_strength_e strength, cpu_word_size_e size_hint) const = 0;
+    virtual std::unique_ptr<user_ctx> create_ctx(security_strength_e strength,
+                                                 cpu_word_size_e size_hint,
+                                                 bool masking) const = 0;
 
     /// Create a context for the pkc instance based on a specific parameter set
-    virtual std::unique_ptr<user_ctx> create_ctx(size_t set, cpu_word_size_e size_hint) const = 0;
+    virtual std::unique_ptr<user_ctx> create_ctx(size_t set,
+                                                 cpu_word_size_e size_hint,
+                                                 bool masking) const = 0;
 
     /// @brief Key generation - creates a public/private key pair
     /// @param ctx The user context containing the key

--- a/src/schemes/signature/dilithium/dilithium_signature.cpp
+++ b/src/schemes/signature/dilithium/dilithium_signature.cpp
@@ -51,7 +51,9 @@ dilithium_signature::~dilithium_signature()
 {
 }
 
-std::unique_ptr<user_ctx> dilithium_signature::create_ctx(security_strength_e bits, cpu_word_size_e size_hint) const
+std::unique_ptr<user_ctx> dilithium_signature::create_ctx(security_strength_e bits,
+                                                          cpu_word_size_e size_hint,
+                                                          bool masking) const
 {
     ctx_dilithium* ctx = new ctx_dilithium(dilithium_signature::bits_2_set(bits));
     if (ctx->get_set() > 3) {
@@ -60,7 +62,9 @@ std::unique_ptr<user_ctx> dilithium_signature::create_ctx(security_strength_e bi
     return std::unique_ptr<user_ctx>(ctx);
 }
 
-std::unique_ptr<user_ctx> dilithium_signature::create_ctx(size_t set, cpu_word_size_e size_hint) const
+std::unique_ptr<user_ctx> dilithium_signature::create_ctx(size_t set,
+                                                          cpu_word_size_e size_hint,
+                                                          bool masking) const
 {
     ctx_dilithium* ctx = new ctx_dilithium(set);
     if (ctx->get_set() > 3) {

--- a/src/schemes/signature/dilithium/dilithium_signature.hpp
+++ b/src/schemes/signature/dilithium/dilithium_signature.hpp
@@ -43,10 +43,15 @@ public:
     virtual ~dilithium_signature();
 
     /// Create a context for the pkc instance based on the required security strength
-    std::unique_ptr<user_ctx> create_ctx(security_strength_e strength, cpu_word_size_e size_hint) const override;
+    std::unique_ptr<user_ctx> create_ctx(security_strength_e bits,
+                                         cpu_word_size_e size_hint,
+                                         bool masking = true) const override;
 
     /// Create a context for the pkc instance based on the parameter set
-    std::unique_ptr<user_ctx> create_ctx(size_t set, cpu_word_size_e size_hint) const override;
+    std::unique_ptr<user_ctx> create_ctx(size_t set,
+                                         cpu_word_size_e size_hint,
+                                         bool masking = true) const override;
+
 
     /// Key manipulation methods
     /// @{

--- a/src/schemes/signature/ecdsa/ctx_ecdsa.hpp
+++ b/src/schemes/signature/ecdsa/ctx_ecdsa.hpp
@@ -299,8 +299,8 @@ private:
             new elliptic::weierstrass_prime_affine<T>(m_params.cfg, g_x, g_y));
 
         // Generate the base point for Shamir's trick
-        core::scalar_coding_e coding = core::ECC_PRE_8;
-        if (core::ECC_BINARY_DUAL == coding) {
+        core::scalar_coding_e coding = core::SCALAR_PRE_8;
+        if (core::SCALAR_BINARY_DUAL == coding) {
             core::mpz<T> g_x_dual(m_params.curve->g_x_dual, 16);
             core::mpz<T> g_y_dual(m_params.curve->g_y_dual, 16);
             auto pt = new elliptic::weierstrass_prime_affine<T>(m_params.cfg, g_x_dual, g_y_dual);
@@ -315,10 +315,10 @@ private:
         m_ecdsa_pk = std::unique_ptr<elliptic::ecc<T>>(new elliptic::ecc<T>(m_params.cfg,
                                                        m_params.field,
                                                        elliptic::POINT_COORD_JACOBIAN,
-                                                       core::ECC_PRE_5,
+                                                       core::SCALAR_PRE_5,
                                                        true));
 
-        if (core::ECC_BINARY_DUAL == coding) {
+        if (core::SCALAR_BINARY_DUAL == coding) {
             m_ecdsa->setup(*m_params.base.get(), *m_params.base_dual.get());
         }
         else {
@@ -360,12 +360,12 @@ private:
         m_ecdsa    = std::unique_ptr<elliptic::ecc<T>>(new elliptic::ecc<T>(m_params.cfg,
                                                        m_params.field,
                                                        elliptic::POINT_COORD_JACOBIAN,
-                                                       core::ECC_PRE_8,
+                                                       core::SCALAR_PRE_8,
                                                        true));
         m_ecdsa_pk = std::unique_ptr<elliptic::ecc<T>>(new elliptic::ecc<T>(m_params.cfg,
                                                        m_params.field,
                                                        elliptic::POINT_COORD_JACOBIAN,
-                                                       core::ECC_PRE_5,
+                                                       core::SCALAR_PRE_5,
                                                        true));
 
         m_ecdsa->setup(*m_params.base.get());

--- a/src/schemes/signature/ecdsa/ecdsa_signature.cpp
+++ b/src/schemes/signature/ecdsa/ecdsa_signature.cpp
@@ -56,7 +56,9 @@ ecdsa_signature::~ecdsa_signature()
 {
 }
 
-std::unique_ptr<user_ctx> ecdsa_signature::create_ctx(security_strength_e bits, cpu_word_size_e size_hint) const
+std::unique_ptr<user_ctx> ecdsa_signature::create_ctx(security_strength_e bits,
+                                                      cpu_word_size_e size_hint,
+                                                      bool masking) const
 {
     user_ctx* ctx;
     switch (size_hint)
@@ -76,7 +78,9 @@ std::unique_ptr<user_ctx> ecdsa_signature::create_ctx(security_strength_e bits, 
     return std::unique_ptr<user_ctx>(ctx);
 }
 
-std::unique_ptr<user_ctx> ecdsa_signature::create_ctx(size_t set, cpu_word_size_e size_hint) const
+std::unique_ptr<user_ctx> ecdsa_signature::create_ctx(size_t set,
+                                                      cpu_word_size_e size_hint,
+                                                      bool masking) const
 {
     user_ctx* ctx;
     switch (size_hint)

--- a/src/schemes/signature/eddsa/ctx_eddsa.hpp
+++ b/src/schemes/signature/eddsa/ctx_eddsa.hpp
@@ -271,12 +271,12 @@ private:
             new elliptic::ecc<T>(m_params.cfg,
                                  m_params.field,
                                  elliptic::POINT_COORD_PROJECTIVE,
-                                 core::ECC_BINARY,
+                                 core::SCALAR_BINARY,
                                  false));
         m_eddsa_pk = std::unique_ptr<elliptic::ecc<T>>(new elliptic::ecc<T>(m_params.cfg,
                                                        m_params.field,
                                                        elliptic::POINT_COORD_PROJECTIVE,
-                                                       core::ECC_BINARY,
+                                                       core::SCALAR_BINARY,
                                                        false));
 
         m_eddsa->setup(*m_params.base.get());

--- a/src/schemes/signature/eddsa/eddsa_signature.cpp
+++ b/src/schemes/signature/eddsa/eddsa_signature.cpp
@@ -61,7 +61,9 @@ eddsa_signature::~eddsa_signature()
 {
 }
 
-std::unique_ptr<user_ctx> eddsa_signature::create_ctx(security_strength_e bits, cpu_word_size_e size_hint) const
+std::unique_ptr<user_ctx> eddsa_signature::create_ctx(security_strength_e bits,
+                                                      cpu_word_size_e size_hint,
+                                                      bool masking) const
 {
     user_ctx* ctx;
     switch (size_hint)
@@ -81,7 +83,9 @@ std::unique_ptr<user_ctx> eddsa_signature::create_ctx(security_strength_e bits, 
     return std::unique_ptr<user_ctx>(ctx);
 }
 
-std::unique_ptr<user_ctx> eddsa_signature::create_ctx(size_t set, cpu_word_size_e size_hint) const
+std::unique_ptr<user_ctx> eddsa_signature::create_ctx(size_t set,
+                                                      cpu_word_size_e size_hint,
+                                                      bool masking) const
 {
     user_ctx* ctx;
     switch (size_hint)

--- a/src/schemes/signature/eddsa/eddsa_signature.hpp
+++ b/src/schemes/signature/eddsa/eddsa_signature.hpp
@@ -38,10 +38,15 @@ public:
     virtual ~eddsa_signature();
 
     /// Create a context for the pkc instance based on the required security strength
-    std::unique_ptr<user_ctx> create_ctx(security_strength_e strength, cpu_word_size_e size_hint) const override;
+    std::unique_ptr<user_ctx> create_ctx(security_strength_e strength,
+                                         cpu_word_size_e size_hint,
+                                         bool masking = true) const override;
 
     /// Create a context for the pkc instance based on the parameter set
-    std::unique_ptr<user_ctx> create_ctx(size_t set, cpu_word_size_e size_hint) const override;
+    std::unique_ptr<user_ctx> create_ctx(size_t set,
+                                         cpu_word_size_e size_hint,
+                                         bool masking = true) const override;
+
 
     /// Key manipulation methods
     /// @{

--- a/src/schemes/signature/falcon/falcon_signature.cpp
+++ b/src/schemes/signature/falcon/falcon_signature.cpp
@@ -60,7 +60,9 @@ falcon_signature::~falcon_signature()
 {
 }
 
-std::unique_ptr<user_ctx> falcon_signature::create_ctx(security_strength_e bits, cpu_word_size_e size_hint) const
+std::unique_ptr<user_ctx> falcon_signature::create_ctx(security_strength_e bits,
+                                                       cpu_word_size_e size_hint,
+                                                       bool masking) const
 {
     ctx_falcon* ctx = new ctx_falcon(falcon_signature::bits_2_set(bits));
     if (ctx->get_set() > 1) {
@@ -69,7 +71,9 @@ std::unique_ptr<user_ctx> falcon_signature::create_ctx(security_strength_e bits,
     return std::unique_ptr<user_ctx>(ctx);
 }
 
-std::unique_ptr<user_ctx> falcon_signature::create_ctx(size_t set, cpu_word_size_e size_hint) const
+std::unique_ptr<user_ctx> falcon_signature::create_ctx(size_t set,
+                                                       cpu_word_size_e size_hint,
+                                                       bool masking) const
 {
     ctx_falcon* ctx = new ctx_falcon(set);
     if (ctx->get_set() > 1) {

--- a/src/schemes/signature/falcon/falcon_signature.hpp
+++ b/src/schemes/signature/falcon/falcon_signature.hpp
@@ -42,10 +42,15 @@ public:
     virtual ~falcon_signature();
 
     /// Create a context for the pkc instance based on the required security strength
-    std::unique_ptr<user_ctx> create_ctx(security_strength_e strength, cpu_word_size_e size_hint) const override;
+    std::unique_ptr<user_ctx> create_ctx(security_strength_e strength,
+                                         cpu_word_size_e size_hint,
+                                         bool masking = true) const override;
 
     /// Create a context for the pkc instance based on the parameter set
-    std::unique_ptr<user_ctx> create_ctx(size_t set, cpu_word_size_e size_hint) const override;
+    std::unique_ptr<user_ctx> create_ctx(size_t set,
+                                         cpu_word_size_e size_hint,
+                                         bool masking = true) const override;
+
 
     /// Key manipulation methods
     /// @{

--- a/src/schemes/signature/rsassa_pss/rsassa_pss_signature.cpp
+++ b/src/schemes/signature/rsassa_pss/rsassa_pss_signature.cpp
@@ -71,15 +71,17 @@ rsassa_pss_signature::~rsassa_pss_signature()
 {
 }
 
-std::unique_ptr<user_ctx> rsassa_pss_signature::create_ctx(security_strength_e bits, cpu_word_size_e size_hint) const
+std::unique_ptr<user_ctx> rsassa_pss_signature::create_ctx(security_strength_e bits,
+                                                           cpu_word_size_e size_hint,
+                                                           bool masking) const
 {
     user_ctx* ctx;
     switch (size_hint)
     {
-        case CPU_WORD_SIZE_16: ctx = new phantom::rsa::ctx_rsa_tmpl<uint16_t>(bits_2_set(bits)); break;
-        case CPU_WORD_SIZE_32: ctx = new phantom::rsa::ctx_rsa_tmpl<uint32_t>(bits_2_set(bits)); break;
+        case CPU_WORD_SIZE_16: ctx = new phantom::rsa::ctx_rsa_tmpl<uint16_t>(bits_2_set(bits), masking); break;
+        case CPU_WORD_SIZE_32: ctx = new phantom::rsa::ctx_rsa_tmpl<uint32_t>(bits_2_set(bits), masking); break;
 #if defined(IS_64BIT)
-        case CPU_WORD_SIZE_64: ctx = new phantom::rsa::ctx_rsa_tmpl<uint64_t>(bits_2_set(bits)); break;
+        case CPU_WORD_SIZE_64: ctx = new phantom::rsa::ctx_rsa_tmpl<uint64_t>(bits_2_set(bits), masking); break;
 #endif
         default: throw std::invalid_argument("size_hint set is out of range");
     }
@@ -91,15 +93,17 @@ std::unique_ptr<user_ctx> rsassa_pss_signature::create_ctx(security_strength_e b
     return std::unique_ptr<user_ctx>(ctx);
 }
 
-std::unique_ptr<user_ctx> rsassa_pss_signature::create_ctx(size_t set, cpu_word_size_e size_hint) const
+std::unique_ptr<user_ctx> rsassa_pss_signature::create_ctx(size_t set,
+                                                           cpu_word_size_e size_hint,
+                                                           bool masking) const
 {
     user_ctx* ctx;
     switch (size_hint)
     {
-        case CPU_WORD_SIZE_16: ctx = new phantom::rsa::ctx_rsa_tmpl<uint16_t>(set); break;
-        case CPU_WORD_SIZE_32: ctx = new phantom::rsa::ctx_rsa_tmpl<uint32_t>(set); break;
+        case CPU_WORD_SIZE_16: ctx = new phantom::rsa::ctx_rsa_tmpl<uint16_t>(set, masking); break;
+        case CPU_WORD_SIZE_32: ctx = new phantom::rsa::ctx_rsa_tmpl<uint32_t>(set, masking); break;
 #if defined(IS_64BIT)
-        case CPU_WORD_SIZE_64: ctx = new phantom::rsa::ctx_rsa_tmpl<uint64_t>(set); break;
+        case CPU_WORD_SIZE_64: ctx = new phantom::rsa::ctx_rsa_tmpl<uint64_t>(set, masking); break;
 #endif
         default: throw std::invalid_argument("size_hint set is out of range");
     }

--- a/src/schemes/signature/rsassa_pss/rsassa_pss_signature.hpp
+++ b/src/schemes/signature/rsassa_pss/rsassa_pss_signature.hpp
@@ -31,10 +31,14 @@ public:
 
     /// Create a context for the pkc instance based on the required security strength
     std::unique_ptr<user_ctx> create_ctx(security_strength_e strength,
-                                         cpu_word_size_e size_hint) const override;
+                                         cpu_word_size_e size_hint,
+                                         bool masking = true) const override;
 
     /// Create a context for the pkc instance based on the parameter set
-    std::unique_ptr<user_ctx> create_ctx(size_t set, cpu_word_size_e size_hint) const override;
+    std::unique_ptr<user_ctx> create_ctx(size_t set,
+                                         cpu_word_size_e size_hint,
+                                         bool masking = true) const override;
+
 
     /// Key manipulation methods
     /// @{

--- a/test/functional/func_sig_ecdsa.cpp
+++ b/test/functional/func_sig_ecdsa.cpp
@@ -18,7 +18,7 @@ using namespace phantom;    // NOLINT
 using namespace utilities;  // NOLINT
 using namespace core;     // NOLINT
 
-#define NUM_ITER   1
+#define NUM_ITER   128
 
 
 int main(int argc, char *argv[])
@@ -49,25 +49,17 @@ int main(int argc, char *argv[])
                 std::cerr << "get_private_key() failed" << std::endl;
                 return EXIT_FAILURE;
             }
-            std::cerr << "!!! privkey = " << mpz<uint8_t>(privkey.data(), privkey.size()).get_str(16) << std::endl;
 
             phantom_vector<uint8_t> pubkey;
             if (!ecdsa.get_public_key(ctx, pubkey)) {
                 std::cerr << "get_private_key() failed" << std::endl;
                 return EXIT_FAILURE;
             }
-            std::cerr << "!!! pubkey = " << mpz<uint8_t>(pubkey.data(), pubkey.size()).get_str(16) << std::endl;
-
-            std::cerr << "!!! j = " << j << std::endl;
 
             phantom_vector<uint8_t> s;
             sw_sign.start();
             ecdsa.sig_sign(ctx, m, s);
             sw_sign.stop();
-
-            std::cerr << "!!! s = " << mpz<uint8_t>(s.data(), s.size()).get_str(16) << std::endl;
-
-            std::cerr << "!!! Verify" << std::endl;
 
             sw_verify.start();
             bool verified = ecdsa.sig_verify(ctx, m, s);

--- a/test/unit/unit_binary_ecc.cpp
+++ b/test/unit/unit_binary_ecc.cpp
@@ -74,7 +74,7 @@ const lest::test specification[] =
         ecc<uint32_t> ec(cfg,
                          field_e::WEIERSTRASS_BINARY_FIELD,
                          type_e::POINT_COORD_AFFINE,
-                         scalar_coding_e::ECC_BINARY);
+                         scalar_coding_e::SCALAR_BINARY);
         retcode_e rc;
 
         auto secret = phantom_vector<uint8_t>();
@@ -100,7 +100,7 @@ const lest::test specification[] =
         ecc<uint32_t> ec(cfg,
                          field_e::WEIERSTRASS_BINARY_FIELD,
                          type_e::POINT_COORD_AFFINE,
-                         scalar_coding_e::ECC_BINARY);
+                         scalar_coding_e::SCALAR_BINARY);
         retcode_e rc;
 
         mpz<uint8_t> k("0", 10);
@@ -125,7 +125,7 @@ const lest::test specification[] =
         ecc_config<uint32_t> cfg = setup_32_b163();
 
         ecc<uint32_t> ec(cfg, field_e::WEIERSTRASS_BINARY_FIELD,
-            type_e::POINT_COORD_AFFINE, scalar_coding_e::ECC_BINARY);
+            type_e::POINT_COORD_AFFINE, scalar_coding_e::SCALAR_BINARY);
 
         mpz<uint8_t> k("1", 10);
         auto secret = phantom_vector<uint8_t>(k.get_limbs().begin(), k.get_limbs().end());
@@ -151,7 +151,7 @@ const lest::test specification[] =
         ecc_config<uint32_t> cfg = setup_32_b163();
 
         ecc<uint32_t> ec(cfg, field_e::WEIERSTRASS_BINARY_FIELD,
-            type_e::POINT_COORD_AFFINE, scalar_coding_e::ECC_BINARY);
+            type_e::POINT_COORD_AFFINE, scalar_coding_e::SCALAR_BINARY);
 
         mpz<uint8_t> k("3", 10);
         auto secret = phantom_vector<uint8_t>(k.get_limbs().begin(), k.get_limbs().end());
@@ -177,7 +177,7 @@ const lest::test specification[] =
         ecc_config<uint32_t> cfg = setup_32_b163();
 
         ecc<uint32_t> ec(cfg, field_e::WEIERSTRASS_BINARY_FIELD,
-            type_e::POINT_COORD_AFFINE, scalar_coding_e::ECC_BINARY);
+            type_e::POINT_COORD_AFFINE, scalar_coding_e::SCALAR_BINARY);
 
         mpz<uint8_t> k("16", 10);
         auto secret = phantom_vector<uint8_t>(k.get_limbs().begin(), k.get_limbs().end());
@@ -203,7 +203,7 @@ const lest::test specification[] =
         ecc_config<uint32_t> cfg = setup_32_b163();
 
         ecc<uint32_t> ec(cfg, field_e::WEIERSTRASS_BINARY_FIELD,
-            type_e::POINT_COORD_AFFINE, scalar_coding_e::ECC_BINARY);
+            type_e::POINT_COORD_AFFINE, scalar_coding_e::SCALAR_BINARY);
 
         mpz<uint8_t> k("20", 10);
         auto secret = phantom_vector<uint8_t>(k.get_limbs().begin(), k.get_limbs().end());
@@ -229,7 +229,7 @@ const lest::test specification[] =
         ecc_config<uint32_t> cfg = setup_32_b163();
 
         ecc<uint32_t> ec(cfg, field_e::WEIERSTRASS_BINARY_FIELD,
-            type_e::POINT_COORD_AFFINE, scalar_coding_e::ECC_BINARY);
+            type_e::POINT_COORD_AFFINE, scalar_coding_e::SCALAR_BINARY);
 
         mpz<uint8_t> k("5846006549323611672814742442876390689256843201586", 10);
         auto secret = phantom_vector<uint8_t>(k.get_limbs().begin(), k.get_limbs().end());
@@ -259,7 +259,7 @@ const lest::test specification[] =
         ecc_config<uint32_t> cfg = setup_32_b233_koblitz();
 
         ecc<uint32_t> ec(cfg, field_e::WEIERSTRASS_BINARY_FIELD,
-            type_e::POINT_COORD_AFFINE, scalar_coding_e::ECC_BINARY);
+            type_e::POINT_COORD_AFFINE, scalar_coding_e::SCALAR_BINARY);
 
         mpz<uint8_t> k("3450873173395281893717377931138512760570940988862252126328087024741342", 10);
         auto secret = phantom_vector<uint8_t>(k.get_limbs().begin(), k.get_limbs().end());
@@ -289,7 +289,7 @@ const lest::test specification[] =
         ecc_config<uint32_t> cfg = setup_32_b233_koblitz();
 
         ecc<uint32_t> ec(cfg, field_e::WEIERSTRASS_BINARY_FIELD,
-            type_e::POINT_COORD_JACOBIAN, scalar_coding_e::ECC_BINARY);
+            type_e::POINT_COORD_JACOBIAN, scalar_coding_e::SCALAR_BINARY);
 
         mpz<uint8_t> k("2", 10);
         auto secret = phantom_vector<uint8_t>(k.get_limbs().begin(), k.get_limbs().end());
@@ -319,7 +319,7 @@ const lest::test specification[] =
         ecc_config<uint32_t> cfg = setup_32_b233_koblitz();
 
         ecc<uint32_t> ec(cfg, field_e::WEIERSTRASS_BINARY_FIELD,
-            type_e::POINT_COORD_JACOBIAN, scalar_coding_e::ECC_BINARY);
+            type_e::POINT_COORD_JACOBIAN, scalar_coding_e::SCALAR_BINARY);
 
         mpz<uint8_t> k("3", 10);
         auto secret = phantom_vector<uint8_t>(k.get_limbs().begin(), k.get_limbs().end());
@@ -349,7 +349,7 @@ const lest::test specification[] =
         ecc_config<uint32_t> cfg = setup_32_b233_koblitz();
 
         ecc<uint32_t> ec(cfg, field_e::WEIERSTRASS_BINARY_FIELD,
-            type_e::POINT_COORD_JACOBIAN, scalar_coding_e::ECC_BINARY);
+            type_e::POINT_COORD_JACOBIAN, scalar_coding_e::SCALAR_BINARY);
 
         mpz<uint8_t> k("3450873173395281893717377931138512760570940988862252126328087024741342", 10);
         auto secret = phantom_vector<uint8_t>(k.get_limbs().begin(), k.get_limbs().end());

--- a/test/unit/unit_curve25519_ecc.cpp
+++ b/test/unit/unit_curve25519_ecc.cpp
@@ -77,7 +77,7 @@ const lest::test specification[] =
         mpz<uint32_t> y1;
         ecc_config<uint32_t> cfg = setup_32_curve25519(reduction_e::REDUCTION_BARRETT);
 
-        ecc<uint32_t> ec(cfg, field_e::MONTGOMERY_PRIME_FIELD, type_e::POINT_COORD_AFFINE, scalar_coding_e::ECC_BINARY);
+        ecc<uint32_t> ec(cfg, field_e::MONTGOMERY_PRIME_FIELD, type_e::POINT_COORD_AFFINE, scalar_coding_e::SCALAR_BINARY);
         retcode_e rc;
 
         auto secret = phantom_vector<uint8_t>();
@@ -100,7 +100,7 @@ const lest::test specification[] =
         mpz<uint32_t> y1;
         ecc_config<uint32_t> cfg = setup_32_curve25519(reduction_e::REDUCTION_BARRETT);
 
-        ecc<uint32_t> ec(cfg, field_e::MONTGOMERY_PRIME_FIELD, type_e::POINT_COORD_AFFINE, scalar_coding_e::ECC_BINARY);
+        ecc<uint32_t> ec(cfg, field_e::MONTGOMERY_PRIME_FIELD, type_e::POINT_COORD_AFFINE, scalar_coding_e::SCALAR_BINARY);
         retcode_e rc;
 
         mpz<uint8_t> k("0", 10);
@@ -124,7 +124,7 @@ const lest::test specification[] =
         mpz<uint32_t> y1("6666666666666666666666666666666666666666666666666666666666666658", 16);
         ecc_config<uint32_t> cfg = setup_32_curve25519(reduction_e::REDUCTION_BARRETT);
 
-        ecc<uint32_t> ec(cfg, field_e::MONTGOMERY_PRIME_FIELD, type_e::POINT_COORD_AFFINE, scalar_coding_e::ECC_BINARY);
+        ecc<uint32_t> ec(cfg, field_e::MONTGOMERY_PRIME_FIELD, type_e::POINT_COORD_AFFINE, scalar_coding_e::SCALAR_BINARY);
 
         mpz<uint8_t> k("1", 10);
         auto secret = phantom_vector<uint8_t>(k.get_limbs().begin(), k.get_limbs().end());
@@ -150,7 +150,7 @@ const lest::test specification[] =
         ecc_config<uint32_t> cfg = setup_32_curve25519(reduction_e::REDUCTION_BARRETT);
 
         ecc<uint32_t> ec(cfg, field_e::MONTGOMERY_PRIME_FIELD,
-            type_e::POINT_COORD_AFFINE, scalar_coding_e::ECC_PRE_2, false);
+            type_e::POINT_COORD_AFFINE, scalar_coding_e::SCALAR_PRE_2, false);
 
         mpz<uint8_t> k("1", 10);
         auto secret = phantom_vector<uint8_t>(k.get_limbs().begin(), k.get_limbs().end());
@@ -179,7 +179,7 @@ const lest::test specification[] =
         ecc_config<uint32_t> cfg = setup_32_curve25519(reduction_e::REDUCTION_BARRETT);
 
         ecc<uint32_t> ec(cfg, field_e::MONTGOMERY_PRIME_FIELD,
-            type_e::POINT_COORD_PROJECTIVE, scalar_coding_e::ECC_MONT_LADDER);
+            type_e::POINT_COORD_PROJECTIVE, scalar_coding_e::SCALAR_MONT_LADDER);
 
         mpz<uint8_t> k("2", 10);
         auto secret = phantom_vector<uint8_t>(k.get_limbs().begin(), k.get_limbs().end());
@@ -207,7 +207,7 @@ const lest::test specification[] =
         ecc_config<uint32_t> cfg = setup_32_curve25519(reduction_e::REDUCTION_MONTGOMERY);
 
         ecc<uint32_t> ec(cfg, field_e::MONTGOMERY_PRIME_FIELD,
-            type_e::POINT_COORD_PROJECTIVE, scalar_coding_e::ECC_MONT_LADDER);
+            type_e::POINT_COORD_PROJECTIVE, scalar_coding_e::SCALAR_MONT_LADDER);
 
         mpz<uint8_t> k("10", 10);
         auto secret = phantom_vector<uint8_t>(k.get_limbs().begin(), k.get_limbs().end());
@@ -235,7 +235,7 @@ const lest::test specification[] =
         ecc_config<uint32_t> cfg = setup_32_curve25519(reduction_e::REDUCTION_BARRETT);
 
         ecc<uint32_t> ec(cfg, field_e::MONTGOMERY_PRIME_FIELD,
-            type_e::POINT_COORD_PROJECTIVE, scalar_coding_e::ECC_MONT_LADDER);
+            type_e::POINT_COORD_PROJECTIVE, scalar_coding_e::SCALAR_MONT_LADDER);
 
         mpz<uint8_t> k("6277101735386680763835789423176059013767194773182842284080", 10);
         auto secret = phantom_vector<uint8_t>(k.get_limbs().begin(), k.get_limbs().end());
@@ -263,7 +263,7 @@ const lest::test specification[] =
         ecc_config<uint32_t> cfg = setup_32_curve25519(reduction_e::REDUCTION_MONTGOMERY);
 
         ecc<uint32_t> ec(cfg, field_e::MONTGOMERY_PRIME_FIELD,
-            type_e::POINT_COORD_PROJECTIVE, scalar_coding_e::ECC_MONT_LADDER);
+            type_e::POINT_COORD_PROJECTIVE, scalar_coding_e::SCALAR_MONT_LADDER);
 
         mpz<uint8_t> k("449A44BA44226A50185AFCC10A4C1462DD5E46824B15163B9D7C52F06BE346A0", 16);
         auto secret = phantom_vector<uint8_t>(k.get_limbs().begin(), k.get_limbs().end());

--- a/test/unit/unit_mpz_additive.cpp
+++ b/test/unit/unit_mpz_additive.cpp
@@ -258,7 +258,7 @@ const lest::test specification[] =
         a.negate();
         EXPECT(a == int16_t(-255));
     },
-    CASE("Addition with modular barrett reduction - 16-bit")
+    CASE("Addition with modular Montgomery reduction - 16-bit")
     {
         mpz<uint16_t> m("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFFF", 16);
         mpz<uint16_t> a(uint16_t(0xFFFF));
@@ -292,7 +292,7 @@ const lest::test specification[] =
         EXPECT(a[0] == 0x0000);
         EXPECT(a.is_negative() == false);
     },
-    CASE("Subtraction with modular barrett reduction - 16-bit")
+    CASE("Subtraction with modular Montgomery reduction - 16-bit")
     {
         mpz<uint16_t> m("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFFF", 16);
         mpz<uint16_t> a("0", 16);
@@ -325,7 +325,7 @@ const lest::test specification[] =
         EXPECT(a.get_str(16, true) == "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFFE");
         EXPECT(a.is_negative() == false);
     },
-    CASE("Addition with modular barrett reduction - 16-bit")
+    CASE("Addition with modular Montgomery reduction - 16-bit")
     {
         mpz<uint16_t> m("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFFF", 16);
         mpz<uint16_t> a("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFFFFFFFFFFFE", 16);

--- a/test/unit/unit_prime_ecc.cpp
+++ b/test/unit/unit_prime_ecc.cpp
@@ -213,7 +213,7 @@ const lest::test specification[] =
         ecc_config<uint32_t> cfg = setup_32_p192();
 
         ecc<uint32_t> ec(cfg, field_e::WEIERSTRASS_PRIME_FIELD,
-            type_e::POINT_COORD_AFFINE, scalar_coding_e::ECC_BINARY);
+            type_e::POINT_COORD_AFFINE, scalar_coding_e::SCALAR_BINARY);
         retcode_e rc;
 
         auto secret = phantom_vector<uint8_t>();
@@ -237,7 +237,7 @@ const lest::test specification[] =
         ecc_config<uint32_t> cfg = setup_32_p192();
 
         ecc<uint32_t> ec(cfg, field_e::WEIERSTRASS_PRIME_FIELD,
-            type_e::POINT_COORD_AFFINE, scalar_coding_e::ECC_BINARY);
+            type_e::POINT_COORD_AFFINE, scalar_coding_e::SCALAR_BINARY);
         retcode_e rc;
 
         mpz<uint8_t> k("0", 10);
@@ -262,7 +262,7 @@ const lest::test specification[] =
         ecc_config<uint32_t> cfg = setup_32_p192();
 
         ecc<uint32_t> ec(cfg, field_e::WEIERSTRASS_PRIME_FIELD,
-            type_e::POINT_COORD_AFFINE, scalar_coding_e::ECC_BINARY);
+            type_e::POINT_COORD_AFFINE, scalar_coding_e::SCALAR_BINARY);
 
         mpz<uint8_t> k("1", 10);
         auto secret = phantom_vector<uint8_t>(k.get_limbs().begin(), k.get_limbs().end());
@@ -288,7 +288,7 @@ const lest::test specification[] =
         ecc_config<uint32_t> cfg = setup_32_p192();
 
         ecc<uint32_t> ec(cfg, field_e::WEIERSTRASS_PRIME_FIELD,
-            type_e::POINT_COORD_AFFINE, scalar_coding_e::ECC_PRE_2, false);
+            type_e::POINT_COORD_AFFINE, scalar_coding_e::SCALAR_PRE_2, false);
 
         mpz<uint8_t> k("1", 10);
         auto secret = phantom_vector<uint8_t>(k.get_limbs().begin(), k.get_limbs().end());
@@ -317,7 +317,7 @@ const lest::test specification[] =
         ecc_config<uint32_t> cfg = setup_32_p192();
 
         ecc<uint32_t> ec(cfg, field_e::WEIERSTRASS_PRIME_FIELD,
-            type_e::POINT_COORD_AFFINE, scalar_coding_e::ECC_BINARY);
+            type_e::POINT_COORD_AFFINE, scalar_coding_e::SCALAR_BINARY);
 
         mpz<uint8_t> k("2", 10);
         auto secret = phantom_vector<uint8_t>(k.get_limbs().begin(), k.get_limbs().end());
@@ -346,7 +346,7 @@ const lest::test specification[] =
         ecc_config<uint32_t> cfg = setup_32_p192();
 
         ecc<uint32_t> ec(cfg, field_e::WEIERSTRASS_PRIME_FIELD,
-            type_e::POINT_COORD_AFFINE, scalar_coding_e::ECC_BINARY);
+            type_e::POINT_COORD_AFFINE, scalar_coding_e::SCALAR_BINARY);
 
         mpz<uint8_t> k("6277101735386680763835789423176059013767194773182842284080", 10);
         auto secret = phantom_vector<uint8_t>(k.get_limbs().begin(), k.get_limbs().end());
@@ -375,7 +375,7 @@ const lest::test specification[] =
         ecc_config<uint32_t> cfg = setup_32_p192();
 
         ecc<uint32_t> ec(cfg, field_e::WEIERSTRASS_PRIME_FIELD,
-            type_e::POINT_COORD_AFFINE, scalar_coding_e::ECC_NAF_2, false);
+            type_e::POINT_COORD_AFFINE, scalar_coding_e::SCALAR_NAF_2, false);
 
         mpz<uint8_t> k("6277101735386680763835789423176059013767194773182842284080", 10);
         auto secret = phantom_vector<uint8_t>(k.get_limbs().begin(), k.get_limbs().end());
@@ -404,7 +404,7 @@ const lest::test specification[] =
         ecc_config<uint32_t> cfg = setup_32_p192();
 
         ecc<uint32_t> ec(cfg, field_e::WEIERSTRASS_PRIME_FIELD,
-            type_e::POINT_COORD_AFFINE, scalar_coding_e::ECC_PRE_2, false);
+            type_e::POINT_COORD_AFFINE, scalar_coding_e::SCALAR_PRE_2, false);
 
         mpz<uint8_t> k("6277101735386680763835789423176059013767194773182842284080", 10);
         auto secret = phantom_vector<uint8_t>(k.get_limbs().begin(), k.get_limbs().end());
@@ -433,7 +433,7 @@ const lest::test specification[] =
         ecc_config<uint32_t> cfg = setup_32_p192();
 
         ecc<uint32_t> ec(cfg, field_e::WEIERSTRASS_PRIME_FIELD,
-            type_e::POINT_COORD_AFFINE, scalar_coding_e::ECC_PRE_4, false);
+            type_e::POINT_COORD_AFFINE, scalar_coding_e::SCALAR_PRE_4, false);
 
         mpz<uint8_t> k("6277101735386680763835789423176059013767194773182842284080", 10);
         auto secret = phantom_vector<uint8_t>(k.get_limbs().begin(), k.get_limbs().end());
@@ -462,7 +462,7 @@ const lest::test specification[] =
         ecc_config<uint32_t> cfg = setup_32_p192();
 
         ecc<uint32_t> ec(cfg, field_e::WEIERSTRASS_PRIME_FIELD,
-            type_e::POINT_COORD_AFFINE, scalar_coding_e::ECC_PRE_6, false);
+            type_e::POINT_COORD_AFFINE, scalar_coding_e::SCALAR_PRE_6, false);
 
         mpz<uint8_t> k("6277101735386680763835789423176059013767194773182842284080", 10);
         auto secret = phantom_vector<uint8_t>(k.get_limbs().begin(), k.get_limbs().end());
@@ -488,7 +488,7 @@ const lest::test specification[] =
         ecc_config<uint32_t> cfg = setup_32_p192();
 
         ecc<uint32_t> ec(cfg, field_e::WEIERSTRASS_PRIME_FIELD,
-            type_e::POINT_COORD_PROJECTIVE, scalar_coding_e::ECC_BINARY);
+            type_e::POINT_COORD_PROJECTIVE, scalar_coding_e::SCALAR_BINARY);
 
         mpz<uint8_t> k("1", 10);
         auto secret = phantom_vector<uint8_t>(k.get_limbs().begin(), k.get_limbs().end());
@@ -517,7 +517,7 @@ const lest::test specification[] =
         ecc_config<uint32_t> cfg = setup_32_p192();
 
         ecc<uint32_t> ec(cfg, field_e::WEIERSTRASS_PRIME_FIELD,
-            type_e::POINT_COORD_PROJECTIVE, scalar_coding_e::ECC_BINARY);
+            type_e::POINT_COORD_PROJECTIVE, scalar_coding_e::SCALAR_BINARY);
 
         mpz<uint8_t> k("2", 10);
         auto secret = phantom_vector<uint8_t>(k.get_limbs().begin(), k.get_limbs().end());
@@ -546,7 +546,7 @@ const lest::test specification[] =
         ecc_config<uint32_t> cfg = setup_32_p192();
 
         ecc<uint32_t> ec(cfg, field_e::WEIERSTRASS_PRIME_FIELD,
-            type_e::POINT_COORD_PROJECTIVE, scalar_coding_e::ECC_BINARY);
+            type_e::POINT_COORD_PROJECTIVE, scalar_coding_e::SCALAR_BINARY);
 
         mpz<uint8_t> k("6277101735386680763835789423176059013767194773182842284080", 10);
         auto secret = phantom_vector<uint8_t>(k.get_limbs().begin(), k.get_limbs().end());
@@ -575,7 +575,7 @@ const lest::test specification[] =
         ecc_config<uint32_t> cfg = setup_32_p192();
 
         ecc<uint32_t> ec(cfg, field_e::WEIERSTRASS_PRIME_FIELD,
-            type_e::POINT_COORD_PROJECTIVE, scalar_coding_e::ECC_NAF_2, false);
+            type_e::POINT_COORD_PROJECTIVE, scalar_coding_e::SCALAR_NAF_2, false);
 
         mpz<uint8_t> k("6277101735386680763835789423176059013767194773182842284080", 10);
         auto secret = phantom_vector<uint8_t>(k.get_limbs().begin(), k.get_limbs().end());
@@ -604,7 +604,7 @@ const lest::test specification[] =
         ecc_config<uint32_t> cfg = setup_32_p192();
 
         ecc<uint32_t> ec(cfg, field_e::WEIERSTRASS_PRIME_FIELD,
-            type_e::POINT_COORD_AFFINE, scalar_coding_e::ECC_NAF_3, false);
+            type_e::POINT_COORD_AFFINE, scalar_coding_e::SCALAR_NAF_3, false);
 
         mpz<uint8_t> k("6277101735386680763835789423176059013767194773182842284080", 10);
         auto secret = phantom_vector<uint8_t>(k.get_limbs().begin(), k.get_limbs().end());
@@ -630,7 +630,7 @@ const lest::test specification[] =
         ecc_config<uint32_t> cfg = setup_32_p192();
 
         ecc<uint32_t> ec(cfg, field_e::WEIERSTRASS_PRIME_FIELD,
-            type_e::POINT_COORD_JACOBIAN, scalar_coding_e::ECC_BINARY);
+            type_e::POINT_COORD_JACOBIAN, scalar_coding_e::SCALAR_BINARY);
 
         mpz<uint8_t> k("1", 10);
         auto secret = phantom_vector<uint8_t>(k.get_limbs().begin(), k.get_limbs().end());
@@ -659,7 +659,7 @@ const lest::test specification[] =
         ecc_config<uint32_t> cfg = setup_32_p192();
 
         ecc<uint32_t> ec(cfg, field_e::WEIERSTRASS_PRIME_FIELD,
-            type_e::POINT_COORD_JACOBIAN, scalar_coding_e::ECC_BINARY);
+            type_e::POINT_COORD_JACOBIAN, scalar_coding_e::SCALAR_BINARY);
 
         mpz<uint8_t> k("2", 10);
         auto secret = phantom_vector<uint8_t>(k.get_limbs().begin(), k.get_limbs().end());
@@ -688,7 +688,7 @@ const lest::test specification[] =
         ecc_config<uint32_t> cfg = setup_32_p192();
 
         ecc<uint32_t> ec(cfg, field_e::WEIERSTRASS_PRIME_FIELD,
-            type_e::POINT_COORD_JACOBIAN, scalar_coding_e::ECC_BINARY);
+            type_e::POINT_COORD_JACOBIAN, scalar_coding_e::SCALAR_BINARY);
 
         mpz<uint8_t> k("6277101735386680763835789423176059013767194773182842284080", 10);
         auto secret = phantom_vector<uint8_t>(k.get_limbs().begin(), k.get_limbs().end());
@@ -717,7 +717,7 @@ const lest::test specification[] =
         ecc_config<uint32_t> cfg = setup_32_p192();
 
         ecc<uint32_t> ec(cfg, field_e::WEIERSTRASS_PRIME_FIELD,
-            type_e::POINT_COORD_JACOBIAN, scalar_coding_e::ECC_NAF_2, false);
+            type_e::POINT_COORD_JACOBIAN, scalar_coding_e::SCALAR_NAF_2, false);
 
         mpz<uint8_t> k("6277101735386680763835789423176059013767194773182842284080", 10);
         auto secret = phantom_vector<uint8_t>(k.get_limbs().begin(), k.get_limbs().end());
@@ -736,7 +736,7 @@ const lest::test specification[] =
         EXPECT(xr.get_str(16) == x2.get_str(16));
         EXPECT(yr.get_str(16) == y2.get_str(16));
     },
-    CASE("Projective XZ Montgomery ladder scalar multiplication, ECC_MONT_LADDER, k = large - 32-bit")
+    CASE("Projective XZ Montgomery ladder scalar multiplication, SCALAR_MONT_LADDER, k = large - 32-bit")
     {
         mpz<uint32_t> x1("9", 16);
         mpz<uint32_t> y1("20AE19A1B8A086B4E01EDD2C7748D14C923D4D7E6D7C61B229E9C5A27ECED3D9", 16);
@@ -746,7 +746,7 @@ const lest::test specification[] =
         ecc_config<uint32_t> cfg = setup_32_p255();
 
         ecc<uint32_t> ec(cfg, field_e::MONTGOMERY_PRIME_FIELD,
-            type_e::POINT_COORD_PROJECTIVE, scalar_coding_e::ECC_MONT_LADDER, false);
+            type_e::POINT_COORD_PROJECTIVE, scalar_coding_e::SCALAR_MONT_LADDER, false);
 
         mpz<uint8_t> k("6277101735386680763835789423176059013767194773182842284080", 10);
         auto secret = phantom_vector<uint8_t>(k.get_limbs().begin(), k.get_limbs().end());
@@ -775,7 +775,7 @@ const lest::test specification[] =
 
         ecc_config<uint32_t> cfg = setup_32_edwards448();
 
-        ecc<uint32_t> ec(cfg, field_e::EDWARDS_PRIME_FIELD, type_e::POINT_COORD_AFFINE, scalar_coding_e::ECC_BINARY);
+        ecc<uint32_t> ec(cfg, field_e::EDWARDS_PRIME_FIELD, type_e::POINT_COORD_AFFINE, scalar_coding_e::SCALAR_BINARY);
 
         mpz<uint8_t> k("2", 10);
         auto secret = phantom_vector<uint8_t>(k.get_limbs().begin(), k.get_limbs().end());
@@ -805,7 +805,7 @@ const lest::test specification[] =
 
         ecc_config<uint32_t> cfg = setup_32_edwards448();
 
-        ecc<uint32_t> ec(cfg, field_e::EDWARDS_PRIME_FIELD, type_e::POINT_COORD_AFFINE, scalar_coding_e::ECC_BINARY);
+        ecc<uint32_t> ec(cfg, field_e::EDWARDS_PRIME_FIELD, type_e::POINT_COORD_AFFINE, scalar_coding_e::SCALAR_BINARY);
 
         mpz<uint8_t> k("315879992934921009807084090", 10);
         auto secret = phantom_vector<uint8_t>(k.get_limbs().begin(), k.get_limbs().end());
@@ -835,7 +835,7 @@ const lest::test specification[] =
 
         ecc_config<uint32_t> cfg = setup_32_edwards448();
 
-        ecc<uint32_t> ec(cfg, field_e::EDWARDS_PRIME_FIELD, type_e::POINT_COORD_AFFINE, scalar_coding_e::ECC_BINARY);
+        ecc<uint32_t> ec(cfg, field_e::EDWARDS_PRIME_FIELD, type_e::POINT_COORD_AFFINE, scalar_coding_e::SCALAR_BINARY);
 
         mpz<uint8_t> k("2", 10);
         auto secret = phantom_vector<uint8_t>(k.get_limbs().begin(), k.get_limbs().end());
@@ -865,7 +865,7 @@ const lest::test specification[] =
 
         ecc_config<uint32_t> cfg = setup_32_edwards448();
 
-        ecc<uint32_t> ec(cfg, field_e::EDWARDS_PRIME_FIELD, type_e::POINT_COORD_AFFINE, scalar_coding_e::ECC_BINARY);
+        ecc<uint32_t> ec(cfg, field_e::EDWARDS_PRIME_FIELD, type_e::POINT_COORD_AFFINE, scalar_coding_e::SCALAR_BINARY);
 
         mpz<uint8_t> k("315879992934921009807084090", 10);
         auto secret = phantom_vector<uint8_t>(k.get_limbs().begin(), k.get_limbs().end());
@@ -895,7 +895,7 @@ const lest::test specification[] =
         ecc_config<uint32_t> cfg = setup_32_edwards25519();
 
         ecc<uint32_t> ec(cfg, field_e::EDWARDS_PRIME_FIELD,
-            type_e::POINT_COORD_PROJECTIVE, scalar_coding_e::ECC_BINARY);
+            type_e::POINT_COORD_PROJECTIVE, scalar_coding_e::SCALAR_BINARY);
 
         mpz<uint8_t> k("36144925721603087658594284515452164870581325872720374094707712194495455132720", 10);
         phantom_vector<uint8_t> vec = {


### PR DESCRIPTION
* Adds exponent recoding but is still disabled.
* Adds masking flag to all pkc context with a default enabled state.