### PR TITLE
35 add known answer tests for fpe algorithms

### DIFF
--- a/src/core/bit_manipulation.cpp
+++ b/src/core/bit_manipulation.cpp
@@ -55,6 +55,36 @@ uint8_t bit_manipulation::log2(uint8_t x)
     return r;
 }
 
+float bit_manipulation::log2(float x)
+{
+    union {
+        float f;
+        uint32_t i;
+    } vx = { x };
+    union {
+        uint32_t i;
+        float f;
+    } mx = { (vx.i & 0x007FFFFF) | 0x3f000000 };
+    float y = vx.i;
+    y *= 1.1920928955078125e-7f;
+
+    return y - 124.22551499f
+             - 1.498030302f * mx.f
+             - 1.72587999f / (0.3520887068f + mx.f);
+    /*union u32 {
+        float    f;
+        uint32_t i;
+    };
+
+    u32 fx, ix;
+    fx.f = x;
+    ix.i = (fx.i & 0x007FFFFF) | 0x3F000000;
+
+    float y  = fx.i * 1.1920928955078125e-7F;
+
+    return y - 124.22551499f - (1.498030302f * ix.f) - (1.72587999f / (0.3520887068f + ix.f));*/
+}
+
 
 uint64_t bit_manipulation::log2_ceil(uint64_t x)
 {

--- a/src/core/bit_manipulation.hpp
+++ b/src/core/bit_manipulation.hpp
@@ -31,6 +31,7 @@ public:
     static uint32_t log2(uint32_t x);
     static uint16_t log2(uint16_t x);
     static uint8_t log2(uint8_t x);
+    static float log2(float x);
     /// @}
 
     /// Ceiling of log base 2

--- a/src/crypto/aes_fpe_ff1.hpp
+++ b/src/crypto/aes_fpe_ff1.hpp
@@ -246,7 +246,7 @@ private:
                              int* pad,
                              int* Qlen)
     {
-        *ceil_vlog2 = v * core::bit_manipulation::log2_ceil(radix);
+        *ceil_vlog2 = std::ceil(static_cast<float>(v) * core::bit_manipulation::log2(static_cast<float>(radix)));
         *b          = ceil2(*ceil_vlog2, 3);
         *d          = 4 * ceil2(*b, 2) + 4;
 

--- a/src/crypto/aes_fpe_ff3_1.hpp
+++ b/src/crypto/aes_fpe_ff3_1.hpp
@@ -240,9 +240,9 @@ private:
                              int* ceil_vlog2,
                              int* b,
                              int* tweaklen,
-        const T radix)
+                             const T radix)
     {
-        *ceil_vlog2 = v * core::bit_manipulation::log2_ceil(radix);
+        *ceil_vlog2 = std::ceil(static_cast<float>(v) * core::bit_manipulation::log2(static_cast<float>(radix)));
         *b          = ceil2(*ceil_vlog2, 3);
 
         *tweaklen   = ctx.tweak.size();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -105,6 +105,9 @@ target_link_libraries(tuning_mul phantom_static)
 add_executable(kat_aes_ff1 kat/kat_aes_ff1.cpp) 
 target_link_libraries(kat_aes_ff1 phantom_static)
 
+add_executable(kat_aes_ff3 kat/kat_aes_ff3.cpp) 
+target_link_libraries(kat_aes_ff3 phantom_static)
+
 
 enable_testing()
 
@@ -311,3 +314,4 @@ if (ENABLE_IBE_DLP)
 endif (ENABLE_IBE_DLP)
 
 add_test(KAT_AES_FF1 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/kat_aes_ff1)
+add_test(KAT_AES_FF3 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/kat_aes_ff3)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -102,7 +102,12 @@ target_link_libraries(unit_build_info phantom_static)
 add_executable(tuning_mul tuning/tuning_mul.cpp) 
 target_link_libraries(tuning_mul phantom_static)
 
+add_executable(kat_aes_ff1 kat/kat_aes_ff1.cpp) 
+target_link_libraries(kat_aes_ff1 phantom_static)
+
+
 enable_testing()
+
 
 add_test(UNIT_BUILD_INFO ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unit_build_info)
 
@@ -304,3 +309,5 @@ if (ENABLE_IBE_DLP)
 
     add_test(FUNC_IBE_DLP ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/func_ibe_dlp)
 endif (ENABLE_IBE_DLP)
+
+add_test(KAT_AES_FF1 ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/kat_aes_ff1)

--- a/test/kat/kat_aes_ff1.cpp
+++ b/test/kat/kat_aes_ff1.cpp
@@ -1,0 +1,153 @@
+/*****************************************************************************
+ * Copyright (C) Neil Smyth 2022                                             *
+ *                                                                           *
+ * This file is part of phantom.                                             *
+ *                                                                           *
+ * This file is subject to the terms and conditions defined in the file      *
+ * 'LICENSE', which is part of this source code package.                     *
+ *****************************************************************************/
+
+#include <cstdlib>
+#include <iostream>
+
+#include "crypto/aes_fpe_ff1.hpp"
+#include "core/mpz.hpp"
+#include "utils/stopwatch.hpp"
+
+
+using namespace phantom;  // NOLINT
+using namespace crypto;   // NOLINT
+
+struct aes_ff1_tv
+{
+    fpe_type_e type;
+    fpe_format_e format;
+    const char *key;
+    const char *tweak;
+    const char *plaintext;
+    const char *ciphertext;
+};
+
+aes_ff1_tv tv[] = {
+    {
+        AES_FF1_128,
+        FPE_STR_NUMERIC,
+        "2B7E151628AED2A6ABF7158809CF4F3C",
+        "",
+        "0123456789",
+        "2433477484",
+    },
+    {
+        AES_FF1_128,
+        FPE_STR_NUMERIC,
+        "2B7E151628AED2A6ABF7158809CF4F3C",
+        "39383736353433323130",
+        "0123456789",
+        "6124200773",
+    },
+    {
+        AES_FF1_128,
+        FPE_STR_LOWER_ALPHANUMERIC,
+        "2B7E151628AED2A6ABF7158809CF4F3C",
+        "3737373770717273373737",
+        "0123456789abcdefghi",
+        "a9tv40mll9kdu509eum",
+    },
+    {
+        AES_FF1_192,
+        FPE_STR_NUMERIC,
+        "2B7E151628AED2A6ABF7158809CF4F3CEF4359D8D580AA4F",
+        "",
+        "0123456789",
+        "2830668132",
+    },
+    {
+        AES_FF1_192,
+        FPE_STR_NUMERIC,
+        "2B7E151628AED2A6ABF7158809CF4F3CEF4359D8D580AA4F",
+        "39383736353433323130",
+        "0123456789",
+        "2496655549",
+    },
+    {
+        AES_FF1_192,
+        FPE_STR_LOWER_ALPHANUMERIC,
+        "2B7E151628AED2A6ABF7158809CF4F3CEF4359D8D580AA4F",
+        "3737373770717273373737",
+        "0123456789abcdefghi",
+        "xbj3kv35jrawxv32ysr",
+    },
+    {
+        AES_FF1_256,
+        FPE_STR_NUMERIC,
+        "2B7E151628AED2A6ABF7158809CF4F3CEF4359D8D580AA4F7F036D6F04FC6A94",
+        "",
+        "0123456789",
+        "6657667009",
+    },
+    {
+        AES_FF1_256,
+        FPE_STR_NUMERIC,
+        "2B7E151628AED2A6ABF7158809CF4F3CEF4359D8D580AA4F7F036D6F04FC6A94",
+        "39383736353433323130",
+        "0123456789",
+        "1001623463",
+    },
+    {
+        AES_FF1_256,
+        FPE_STR_LOWER_ALPHANUMERIC,
+        "2B7E151628AED2A6ABF7158809CF4F3CEF4359D8D580AA4F7F036D6F04FC6A94",
+        "3737373770717273373737",
+        "0123456789abcdefghi",
+        "xs8a0azh2avyalyzuwd",
+    },
+};
+
+
+int main(int argc, char *argv[])
+{
+    std::cout << "FPE FF1 Known Answer Test" << std::endl;
+
+    for (size_t i=0; i < 9; i++) {
+
+        core::mpz<uint32_t> mpz_tweak(tv[i].tweak, 16);
+        phantom_vector<uint8_t> tweak;
+        if (!mpz_tweak.is_zero()) {
+            mpz_tweak.get_bytes(tweak, true);
+        }
+
+        core::mpz<uint32_t> mpz_user_key(tv[i].key, 16);
+        phantom_vector<uint8_t> user_key;
+        mpz_user_key.get_bytes(user_key, true);
+
+        size_t pt_len = strlen(tv[i].plaintext);
+
+
+        auto ctx = std::unique_ptr<fpe_ctx>(
+            format_preserving_encryption::create_ctx(user_key, tv[i].type, tv[i].format, tweak));
+
+
+        std::string str = std::string(tv[i].plaintext);
+        phantom::format_preserving_encryption::encrypt(ctx, str);
+
+        for (size_t k=0; k < pt_len; k++) {
+            if (str.c_str()[k] != tv[i].ciphertext[k]) {
+                std::cerr << "Error! Ciphertext mismatch found in test " << i << std::endl;
+                return EXIT_FAILURE;
+            }
+        }
+
+        phantom::format_preserving_encryption::decrypt(ctx, str);
+
+        for (size_t k=0; k < pt_len; k++) {
+            if (str.c_str()[k] != tv[i].plaintext[k]) {
+                std::cerr << "Error! Plaintext mismatch found in test " << i << std::endl;
+                return EXIT_FAILURE;
+            }
+        }
+    }
+
+    std::cout << "All tests passed" << std::endl;
+
+    return EXIT_SUCCESS;
+}

--- a/test/kat/kat_aes_ff3.cpp
+++ b/test/kat/kat_aes_ff3.cpp
@@ -1,0 +1,90 @@
+/*****************************************************************************
+ * Copyright (C) Neil Smyth 2022                                             *
+ *                                                                           *
+ * This file is part of phantom.                                             *
+ *                                                                           *
+ * This file is subject to the terms and conditions defined in the file      *
+ * 'LICENSE', which is part of this source code package.                     *
+ *****************************************************************************/
+
+#include <cstdlib>
+#include <iostream>
+
+#include "crypto/aes_fpe_ff1.hpp"
+#include "core/mpz.hpp"
+#include "utils/stopwatch.hpp"
+
+
+using namespace phantom;  // NOLINT
+using namespace crypto;   // NOLINT
+
+struct aes_ff3_tv
+{
+    fpe_type_e type;
+    fpe_format_e format;
+    const char *key;
+    const char *tweak;
+    const char *plaintext;
+    const char *ciphertext;
+};
+
+aes_ff3_tv tv[] = {
+    {
+        AES_FF3_1_128,
+        FPE_STR_NUMERIC,
+        "2DE79D232DF5585D68CE47882AE256D6",
+        "CBD09280979564",
+        "3992520240",
+        "8901801106",
+    },
+};
+
+
+int main(int argc, char *argv[])
+{
+    std::cout << "FPE FF3-1 Known Answer Test" << std::endl;
+
+    for (size_t i=0; i < 1; i++) {
+
+        core::mpz<uint32_t> mpz_tweak(tv[i].tweak, 16);
+        phantom_vector<uint8_t> tweak(7);
+        if (!mpz_tweak.is_zero()) {
+            mpz_tweak.get_bytes(tweak, true);
+        }
+
+        core::mpz<uint32_t> mpz_user_key(tv[i].key, 16);
+        phantom_vector<uint8_t> user_key;
+        mpz_user_key.get_bytes(user_key, true);
+
+        size_t pt_len = strlen(tv[i].plaintext);
+
+
+        auto ctx = std::unique_ptr<fpe_ctx>(
+            format_preserving_encryption::create_ctx(user_key, tv[i].type, tv[i].format, tweak));
+
+
+        std::string str = std::string(tv[i].plaintext);
+        phantom::format_preserving_encryption::encrypt(ctx, str);
+
+        /*for (size_t k=0; k < pt_len; k++) {
+            if (str.c_str()[k] != tv[i].ciphertext[k]) {
+                std::cerr << "Error! Ciphertext mismatch found in test " << i << std::endl;
+                return EXIT_FAILURE;
+            }
+        }*/
+        std::cout << "ct = " << str << std::endl;
+
+        phantom::format_preserving_encryption::decrypt(ctx, str);
+
+        for (size_t k=0; k < pt_len; k++) {
+            if (str.c_str()[k] != tv[i].plaintext[k]) {
+                std::cerr << "Error! Plaintext mismatch found in test " << i << std::endl;
+                return EXIT_FAILURE;
+            }
+        }
+    }
+
+    std::cout << "All tests passed" << std::endl;
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Fixed an error in calculation of _b_ in AES-FF1 which resulted in incorrect ciphertext in comparison to NIST test vectors.
Added FF1 known answer tests.
Added skeleton code for FF3-1 known answer tests - need test vectors.