### PR TITLE
RSA Montgomery ladder, improved parameter set flexibility

### DIFF
--- a/src/rsa/rsa_cryptosystem.cpp
+++ b/src/rsa/rsa_cryptosystem.cpp
@@ -329,9 +329,9 @@ bool rsa_cryptosystem<T>::mgf1(crypto::hash* h, phantom_vector<uint8_t>& mask, s
     for (uint32_t counter=0; counter < ((masklen + hlen - 1) / hlen) - 1; counter++) {
 
         uint8_t ctr[4] = { uint8_t((counter >>  0) & 0xff),
-                            uint8_t((counter >>  8) & 0xff),
-                            uint8_t((counter >> 16) & 0xff),
-                            uint8_t((counter >> 24) & 0xff) };
+                           uint8_t((counter >>  8) & 0xff),
+                           uint8_t((counter >> 16) & 0xff),
+                           uint8_t((counter >> 24) & 0xff) };
 
         h->init(hblocklen);
         h->update(seed.data(), seed.size());
@@ -397,12 +397,10 @@ rsacode_e rsa_cryptosystem<T>::exponentiation(core::mpz<T>& r, core::mpz<T>& b, 
 
     // Square-and-multiply
     rsacode_e rsacode;
-    /*
     if (core::SCALAR_MONT_LADDER == m_coding_type) {
         rsacode = montgomery_ladder(r, b, bitgen, num_bits, w, sub_offset, cfg);
     }
-    else */
-    {
+    else {
         rsacode = square_and_multiply(r, b, bitgen, num_bits, w, sub_offset, cfg);
     }
 
@@ -445,7 +443,7 @@ rsacode_e rsa_cryptosystem<T>::square_and_multiply(core::mpz<T>& r, const core::
 
             // Determine the value to be multiplied
             core::mpz<T>* mpz_b = subtract ? m_base_pre[sub_idx].get()
-                                            : m_base_pre[pre_idx].get();
+                                           : m_base_pre[pre_idx].get();
 
             r.mul_mod(*mpz_b, cfg);
         }
@@ -477,15 +475,10 @@ rsacode_e rsa_cryptosystem<T>::montgomery_ladder(core::mpz<T>& r, const core::mp
     }
 
     // Set the initial value according to the encoding - it is guaranteed to be positive non-zero
-    if (core::REDUCTION_MONTGOMERY == cfg.reduction) {
-        r = cfg.mont_R2;
-    }
-    else {
-        r.set(T(1));
-    }
+    r.set(*m_base_pre[0].get());
 
     core::mpz<T> b1;
-    b1.set(b);
+    b1.set(*m_base_pre[0].get());
     b1.square_mod(cfg);
 
     // Set pointers
@@ -526,7 +519,7 @@ bool rsa_cryptosystem<T>::rsa_public_exponentiation(ctx_rsa_tmpl<T>& ctx, core::
 template<typename T>
 bool rsa_cryptosystem<T>::rsa_private_exponentiation(ctx_rsa_tmpl<T>& ctx, core::mpz<T> c, core::mpz<T>& m)
 {
-    if (false) {
+    if (ctx.exp1().is_zero() || ctx.exp2().is_zero()) {
         if (RSA_OK != exponentiation(m, c, ctx.d(), ctx.mod())) {
             return false;
         }

--- a/src/rsa/rsa_cryptosystem.hpp
+++ b/src/rsa/rsa_cryptosystem.hpp
@@ -32,12 +32,6 @@ namespace phantom {
 namespace rsa {
 
 
-/// Definitions for the Kyber parameters
-struct rsa_set_t {
-    uint16_t set;
-    uint16_t n_bits;
-};
-
 /// An enumerated type for RSA return codes
 enum rsacode_e {
     RSA_OK = 0,

--- a/src/schemes/pke/rsaes_oaep/rsaes_oaep_pke.cpp
+++ b/src/schemes/pke/rsaes_oaep/rsaes_oaep_pke.cpp
@@ -26,22 +26,22 @@ template<typename T>
 using rsa_oaep = phantom::rsa::rsa_cryptosystem_oaep<T>;
 
 const phantom::rsa::rsa_set_t rsaes_oaep_pke::m_params[16] = {
-    {0, 1024},
-    {1, 2048},
-    {2, 3072},
-    {3, 4096},
-    {4, 5120},
-    {5, 6144},
-    {6, 7168},
-    {7, 8192},
-    {8, 9216},
-    {9, 10240},
-    {10, 11264},
-    {11, 12288},
-    {12, 13312},
-    {13, 14336},
-    {14, 15360},
-    {15, 16384},
+    {0,  HASH_SHA2_224, 1024,  "65537"},
+    {1,  HASH_SHA2_224, 2048,  "65537"},
+    {2,  HASH_SHA2_256, 3072,  "65537"},
+    {3,  HASH_SHA2_256, 4096,  "65537"},
+    {4,  HASH_SHA2_256, 5120,  "65537"},
+    {5,  HASH_SHA2_256, 6144,  "65537"},
+    {6,  HASH_SHA2_256, 7168,  "65537"},
+    {7,  HASH_SHA2_384, 8192,  "65537"},
+    {8,  HASH_SHA2_384, 9216,  "65537"},
+    {9,  HASH_SHA2_384, 10240, "65537"},
+    {10, HASH_SHA2_384, 11264, "65537"},
+    {11, HASH_SHA2_384, 12288, "65537"},
+    {12, HASH_SHA2_384, 13312, "65537"},
+    {13, HASH_SHA2_384, 14336, "65537"},
+    {14, HASH_SHA2_512, 15360, "65537"},
+    {15, HASH_SHA2_512, 16384, "65537"},
 };
 
 size_t rsaes_oaep_pke::bits_2_set(security_strength_e bits)
@@ -51,13 +51,13 @@ size_t rsaes_oaep_pke::bits_2_set(security_strength_e bits)
     switch (bits)
     {
         case SECURITY_STRENGTH_60:
-        case SECURITY_STRENGTH_80:
-        case SECURITY_STRENGTH_96:  set = 0; break;
+        case SECURITY_STRENGTH_80:  set = 0; break;
+        case SECURITY_STRENGTH_96:  set = 1; break;
 
-        case SECURITY_STRENGTH_112:
-        case SECURITY_STRENGTH_128: set = 1; break;
+        case SECURITY_STRENGTH_112: set = 2; break;
+        case SECURITY_STRENGTH_128: set = 3; break;
 
-        case SECURITY_STRENGTH_160: set = 2; break;
+        case SECURITY_STRENGTH_160: set = 4; break;
 
         default: throw std::invalid_argument("Security strength is invalid");
     }
@@ -78,41 +78,27 @@ std::unique_ptr<user_ctx> rsaes_oaep_pke::create_ctx(security_strength_e bits,
                                                      cpu_word_size_e size_hint,
                                                      bool masking) const
 {
-    user_ctx* ctx;
-    switch (size_hint)
-    {
-        case CPU_WORD_SIZE_16: {
-            ctx = new phantom::rsa::ctx_rsa_tmpl<uint16_t>(2, bits_2_set(bits), masking);
-        } break;
-        case CPU_WORD_SIZE_32: {
-            ctx = new phantom::rsa::ctx_rsa_tmpl<uint32_t>(2, bits_2_set(bits), masking);
-        } break;
-#if defined(IS_64BIT)
-        case CPU_WORD_SIZE_64: {
-            ctx = new phantom::rsa::ctx_rsa_tmpl<uint64_t>(2, bits_2_set(bits), masking);
-        } break;
-#endif
-        default: throw std::invalid_argument("size_hint set is out of range");;
-    }
-
-    if ((ctx->get_set() & 0xff) > 5) {
-        throw std::invalid_argument("Parameter set is out of range");
-    }
-
-    return std::unique_ptr<user_ctx>(ctx);
+    size_t set = bits_2_set(bits);
+    return create_ctx(set, size_hint, masking);
 }
 
 std::unique_ptr<user_ctx> rsaes_oaep_pke::create_ctx(size_t set,
                                                      cpu_word_size_e size_hint,
                                                      bool masking) const
 {
+    // Obtain the hash from the parameter set
+    hash_alg_e hash = static_cast<hash_alg_e>((set >> 8) & 0x1f);
+
     user_ctx* ctx;
     switch (size_hint)
     {
-        case CPU_WORD_SIZE_16: ctx = new phantom::rsa::ctx_rsa_tmpl<uint16_t>(2, set, masking); break;
-        case CPU_WORD_SIZE_32: ctx = new phantom::rsa::ctx_rsa_tmpl<uint32_t>(2, set, masking); break;
+        case CPU_WORD_SIZE_16:
+            ctx = new phantom::rsa::ctx_rsa_tmpl<uint16_t>(PKC_PKE_RSAES_OAEP, hash, 2, set, &m_params[0], 16, masking); break;
+        case CPU_WORD_SIZE_32:
+            ctx = new phantom::rsa::ctx_rsa_tmpl<uint32_t>(PKC_PKE_RSAES_OAEP, hash, 2, set, &m_params[0], 16, masking); break;
 #if defined(IS_64BIT)
-        case CPU_WORD_SIZE_64: ctx = new phantom::rsa::ctx_rsa_tmpl<uint64_t>(2, set, masking); break;
+        case CPU_WORD_SIZE_64:
+            ctx = new phantom::rsa::ctx_rsa_tmpl<uint64_t>(PKC_PKE_RSAES_OAEP, hash, 2, set, &m_params[0], 16, masking); break;
 #endif
         default: throw std::invalid_argument("size_hint set is out of range");;
     }

--- a/src/schemes/pke/rsaes_oaep/rsaes_oaep_pke.cpp
+++ b/src/schemes/pke/rsaes_oaep/rsaes_oaep_pke.cpp
@@ -93,12 +93,18 @@ std::unique_ptr<user_ctx> rsaes_oaep_pke::create_ctx(size_t set,
     switch (size_hint)
     {
         case CPU_WORD_SIZE_16:
-            ctx = new phantom::rsa::ctx_rsa_tmpl<uint16_t>(PKC_PKE_RSAES_OAEP, hash, 2, set, &m_params[0], 16, masking); break;
+            ctx = new phantom::rsa::ctx_rsa_tmpl<uint16_t>(PKC_PKE_RSAES_OAEP, hash, 2,
+                                                           set, &m_params[0], 16, masking);
+            break;
         case CPU_WORD_SIZE_32:
-            ctx = new phantom::rsa::ctx_rsa_tmpl<uint32_t>(PKC_PKE_RSAES_OAEP, hash, 2, set, &m_params[0], 16, masking); break;
+            ctx = new phantom::rsa::ctx_rsa_tmpl<uint32_t>(PKC_PKE_RSAES_OAEP, hash, 2,
+                                                           set, &m_params[0], 16, masking);
+            break;
 #if defined(IS_64BIT)
         case CPU_WORD_SIZE_64:
-            ctx = new phantom::rsa::ctx_rsa_tmpl<uint64_t>(PKC_PKE_RSAES_OAEP, hash, 2, set, &m_params[0], 16, masking); break;
+            ctx = new phantom::rsa::ctx_rsa_tmpl<uint64_t>(PKC_PKE_RSAES_OAEP, hash, 2,
+                                                           set, &m_params[0], 16, masking);
+            break;
 #endif
         default: throw std::invalid_argument("size_hint set is out of range");;
     }

--- a/src/schemes/signature/rsassa_pss/rsassa_pss_signature.cpp
+++ b/src/schemes/signature/rsassa_pss/rsassa_pss_signature.cpp
@@ -89,12 +89,18 @@ std::unique_ptr<user_ctx> rsassa_pss_signature::create_ctx(size_t set,
     switch (size_hint)
     {
         case CPU_WORD_SIZE_16:
-            ctx = new phantom::rsa::ctx_rsa_tmpl<uint16_t>(PKC_SIG_RSASSA_PSS, hash, 16, set, &m_params[0], 16, masking); break;
+            ctx = new phantom::rsa::ctx_rsa_tmpl<uint16_t>(PKC_SIG_RSASSA_PSS, hash, 16,
+                                                           set, &m_params[0], 16, masking);
+            break;
         case CPU_WORD_SIZE_32:
-            ctx = new phantom::rsa::ctx_rsa_tmpl<uint32_t>(PKC_SIG_RSASSA_PSS, hash, 16, set, &m_params[0], 16, masking); break;
+            ctx = new phantom::rsa::ctx_rsa_tmpl<uint32_t>(PKC_SIG_RSASSA_PSS, hash, 16,
+                                                           set, &m_params[0], 16, masking);
+            break;
 #if defined(IS_64BIT)
         case CPU_WORD_SIZE_64:
-            ctx = new phantom::rsa::ctx_rsa_tmpl<uint64_t>(PKC_SIG_RSASSA_PSS, hash, 16, set, &m_params[0], 16, masking); break;
+            ctx = new phantom::rsa::ctx_rsa_tmpl<uint64_t>(PKC_SIG_RSASSA_PSS, hash, 16,
+                                                           set, &m_params[0], 16, masking);
+            break;
 #endif
         default: throw std::invalid_argument("size_hint set is out of range");
     }

--- a/src/schemes/signature/rsassa_pss/rsassa_pss_signature.hpp
+++ b/src/schemes/signature/rsassa_pss/rsassa_pss_signature.hpp
@@ -79,7 +79,7 @@ private:
     static size_t bits_2_set(security_strength_e bits);
 
     /// RSA parameter sets
-    static const phantom::rsa::rsa_set_t m_params[17];
+    static const phantom::rsa::rsa_set_t m_params[16];
 };
 
 }  // namespace schemes


### PR DESCRIPTION
Added Montgomery ladder support for sensitive encryption and signing applications.
Parameter sets now contain hash algorithm and predefined exponent values - it is intended to expand this in future to allow users to define custom parameter sets.

Associated with Issue #3.