### PR TITLE
SHA-NI support

### DIFF
--- a/src/crypto/hash_sha2.cpp
+++ b/src/crypto/hash_sha2.cpp
@@ -10,206 +10,13 @@
 #include "crypto/hash_sha2.hpp"
 #include <algorithm>
 #include <climits>
+#include "crypto/sha2_core_generic.hpp"
+#include "crypto/sha2_core_ni.hpp"
 #include "./phantom_memory.hpp"
 
 
 namespace phantom {
 namespace crypto {
-
-
-alignas(DEFAULT_MEM_ALIGNMENT) const uint32_t hash_sha2::k256[64] = {
-    UINT32_C(0x428a2f98),
-    UINT32_C(0x71374491),
-    UINT32_C(0xb5c0fbcf),
-    UINT32_C(0xe9b5dba5),
-    UINT32_C(0x3956c25b),
-    UINT32_C(0x59f111f1),
-    UINT32_C(0x923f82a4),
-    UINT32_C(0xab1c5ed5),
-    UINT32_C(0xd807aa98),
-    UINT32_C(0x12835b01),
-    UINT32_C(0x243185be),
-    UINT32_C(0x550c7dc3),
-    UINT32_C(0x72be5d74),
-    UINT32_C(0x80deb1fe),
-    UINT32_C(0x9bdc06a7),
-    UINT32_C(0xc19bf174),
-    UINT32_C(0xe49b69c1),
-    UINT32_C(0xefbe4786),
-    UINT32_C(0x0fc19dc6),
-    UINT32_C(0x240ca1cc),
-    UINT32_C(0x2de92c6f),
-    UINT32_C(0x4a7484aa),
-    UINT32_C(0x5cb0a9dc),
-    UINT32_C(0x76f988da),
-    UINT32_C(0x983e5152),
-    UINT32_C(0xa831c66d),
-    UINT32_C(0xb00327c8),
-    UINT32_C(0xbf597fc7),
-    UINT32_C(0xc6e00bf3),
-    UINT32_C(0xd5a79147),
-    UINT32_C(0x06ca6351),
-    UINT32_C(0x14292967),
-    UINT32_C(0x27b70a85),
-    UINT32_C(0x2e1b2138),
-    UINT32_C(0x4d2c6dfc),
-    UINT32_C(0x53380d13),
-    UINT32_C(0x650a7354),
-    UINT32_C(0x766a0abb),
-    UINT32_C(0x81c2c92e),
-    UINT32_C(0x92722c85),
-    UINT32_C(0xa2bfe8a1),
-    UINT32_C(0xa81a664b),
-    UINT32_C(0xc24b8b70),
-    UINT32_C(0xc76c51a3),
-    UINT32_C(0xd192e819),
-    UINT32_C(0xd6990624),
-    UINT32_C(0xf40e3585),
-    UINT32_C(0x106aa070),
-    UINT32_C(0x19a4c116),
-    UINT32_C(0x1e376c08),
-    UINT32_C(0x2748774c),
-    UINT32_C(0x34b0bcb5),
-    UINT32_C(0x391c0cb3),
-    UINT32_C(0x4ed8aa4a),
-    UINT32_C(0x5b9cca4f),
-    UINT32_C(0x682e6ff3),
-    UINT32_C(0x748f82ee),
-    UINT32_C(0x78a5636f),
-    UINT32_C(0x84c87814),
-    UINT32_C(0x8cc70208),
-    UINT32_C(0x90befffa),
-    UINT32_C(0xa4506ceb),
-    UINT32_C(0xbef9a3f7),
-    UINT32_C(0xc67178f2),
-};
-
-alignas(DEFAULT_MEM_ALIGNMENT) const uint64_t hash_sha2::k512[80] = {
-    UINT64_C(0x428a2f98d728ae22),
-    UINT64_C(0x7137449123ef65cd),
-    UINT64_C(0xb5c0fbcfec4d3b2f),
-    UINT64_C(0xe9b5dba58189dbbc),
-    UINT64_C(0x3956c25bf348b538),
-    UINT64_C(0x59f111f1b605d019),
-    UINT64_C(0x923f82a4af194f9b),
-    UINT64_C(0xab1c5ed5da6d8118),
-    UINT64_C(0xd807aa98a3030242),
-    UINT64_C(0x12835b0145706fbe),
-    UINT64_C(0x243185be4ee4b28c),
-    UINT64_C(0x550c7dc3d5ffb4e2),
-    UINT64_C(0x72be5d74f27b896f),
-    UINT64_C(0x80deb1fe3b1696b1),
-    UINT64_C(0x9bdc06a725c71235),
-    UINT64_C(0xc19bf174cf692694),
-    UINT64_C(0xe49b69c19ef14ad2),
-    UINT64_C(0xefbe4786384f25e3),
-    UINT64_C(0x0fc19dc68b8cd5b5),
-    UINT64_C(0x240ca1cc77ac9c65),
-    UINT64_C(0x2de92c6f592b0275),
-    UINT64_C(0x4a7484aa6ea6e483),
-    UINT64_C(0x5cb0a9dcbd41fbd4),
-    UINT64_C(0x76f988da831153b5),
-    UINT64_C(0x983e5152ee66dfab),
-    UINT64_C(0xa831c66d2db43210),
-    UINT64_C(0xb00327c898fb213f),
-    UINT64_C(0xbf597fc7beef0ee4),
-    UINT64_C(0xc6e00bf33da88fc2),
-    UINT64_C(0xd5a79147930aa725),
-    UINT64_C(0x06ca6351e003826f),
-    UINT64_C(0x142929670a0e6e70),
-    UINT64_C(0x27b70a8546d22ffc),
-    UINT64_C(0x2e1b21385c26c926),
-    UINT64_C(0x4d2c6dfc5ac42aed),
-    UINT64_C(0x53380d139d95b3df),
-    UINT64_C(0x650a73548baf63de),
-    UINT64_C(0x766a0abb3c77b2a8),
-    UINT64_C(0x81c2c92e47edaee6),
-    UINT64_C(0x92722c851482353b),
-    UINT64_C(0xa2bfe8a14cf10364),
-    UINT64_C(0xa81a664bbc423001),
-    UINT64_C(0xc24b8b70d0f89791),
-    UINT64_C(0xc76c51a30654be30),
-    UINT64_C(0xd192e819d6ef5218),
-    UINT64_C(0xd69906245565a910),
-    UINT64_C(0xf40e35855771202a),
-    UINT64_C(0x106aa07032bbd1b8),
-    UINT64_C(0x19a4c116b8d2d0c8),
-    UINT64_C(0x1e376c085141ab53),
-    UINT64_C(0x2748774cdf8eeb99),
-    UINT64_C(0x34b0bcb5e19b48a8),
-    UINT64_C(0x391c0cb3c5c95a63),
-    UINT64_C(0x4ed8aa4ae3418acb),
-    UINT64_C(0x5b9cca4f7763e373),
-    UINT64_C(0x682e6ff3d6b2b8a3),
-    UINT64_C(0x748f82ee5defb2fc),
-    UINT64_C(0x78a5636f43172f60),
-    UINT64_C(0x84c87814a1f0ab72),
-    UINT64_C(0x8cc702081a6439ec),
-    UINT64_C(0x90befffa23631e28),
-    UINT64_C(0xa4506cebde82bde9),
-    UINT64_C(0xbef9a3f7b2c67915),
-    UINT64_C(0xc67178f2e372532b),
-    UINT64_C(0xca273eceea26619c),
-    UINT64_C(0xd186b8c721c0c207),
-    UINT64_C(0xeada7dd6cde0eb1e),
-    UINT64_C(0xf57d4f7fee6ed178),
-    UINT64_C(0x06f067aa72176fba),
-    UINT64_C(0x0a637dc5a2c898a6),
-    UINT64_C(0x113f9804bef90dae),
-    UINT64_C(0x1b710b35131c471b),
-    UINT64_C(0x28db77f523047d84),
-    UINT64_C(0x32caab7b40c72493),
-    UINT64_C(0x3c9ebe0a15c9bebc),
-    UINT64_C(0x431d67c49c100d4c),
-    UINT64_C(0x4cc5d4becb3e42b6),
-    UINT64_C(0x597f299cfc657e2a),
-    UINT64_C(0x5fcb6fab3ad6faec),
-    UINT64_C(0x6c44198c4a475817)
-};
-
-alignas(DEFAULT_MEM_ALIGNMENT) const uint64_t i512[8] = {
-    UINT64_C(0x6a09e667f3bcc908),
-    UINT64_C(0xbb67ae8584caa73b),
-    UINT64_C(0x3c6ef372fe94f82b),
-    UINT64_C(0xa54ff53a5f1d36f1),
-    UINT64_C(0x510e527fade682d1),
-    UINT64_C(0x9b05688c2b3e6c1f),
-    UINT64_C(0x1f83d9abfb41bd6b),
-    UINT64_C(0x5be0cd19137e2179)
-};
-
-alignas(DEFAULT_MEM_ALIGNMENT) const uint64_t i384[8] = {
-    UINT64_C(0xcbbb9d5dc1059ed8),
-    UINT64_C(0x629a292a367cd507),
-    UINT64_C(0x9159015a3070dd17),
-    UINT64_C(0x152fecd8f70e5939),
-    UINT64_C(0x67332667ffc00b31),
-    UINT64_C(0x8eb44a8768581511),
-    UINT64_C(0xdb0c2e0d64f98fa7),
-    UINT64_C(0x47b5481dbefa4fa4)
-};
-
-alignas(DEFAULT_MEM_ALIGNMENT) const uint32_t i256[8] = {
-    UINT32_C(0x6a09e667),
-    UINT32_C(0xbb67ae85),
-    UINT32_C(0x3c6ef372),
-    UINT32_C(0xa54ff53a),
-    UINT32_C(0x510e527f),
-    UINT32_C(0x9b05688c),
-    UINT32_C(0x1f83d9ab),
-    UINT32_C(0x5be0cd19)
-};
-
-alignas(DEFAULT_MEM_ALIGNMENT) const uint32_t i224[8] = {
-    UINT32_C(0xc1059ed8),
-    UINT32_C(0x367cd507),
-    UINT32_C(0x3070dd17),
-    UINT32_C(0xf70e5939),
-    UINT32_C(0xffc00b31),
-    UINT32_C(0x68581511),
-    UINT32_C(0x64f98fa7),
-    UINT32_C(0xbefa4fa4)
-};
 
 
 void hash_sha2::byteswap(uint32_t* p, size_t n)
@@ -256,7 +63,7 @@ void hash_sha2::sha256_hash(const uint8_t* data, size_t len, sha2_ctx<uint32_t>*
         sp += space;
         space = SHA256_BLOCK_SIZE;
         byteswap(reinterpret_cast<uint32_t*>(w), SHA256_BLOCK_SIZE >> 2);
-        sha_core<uint32_t, 64, k256>(ctx);
+        m_sha256_core_method(ctx);
         pos = 0;
     }
 
@@ -284,7 +91,7 @@ void hash_sha2::sha512_hash(const uint8_t* data, size_t len, sha2_ctx<uint64_t>*
         sp += space;
         space = SHA512_BLOCK_SIZE;
         byteswap(reinterpret_cast<uint64_t*>(w), SHA512_BLOCK_SIZE >> 3);
-        sha_core<uint64_t, 80, k512>(ctx);
+        sha2_core_generic::core<uint64_t, 80, k512>(ctx);
         pos = 0;
     }
 
@@ -312,7 +119,7 @@ void hash_sha2::sha256_end(uint8_t* hval, sha2_ctx<uint32_t>* ctx, size_t hlen)
         if (i < 60) {
             ctx->wbuf[15] = 0;
         }
-        sha_core<uint32_t, 64, k256>(ctx);
+        m_sha256_core_method(ctx);
         i = 0;
     }
     else {
@@ -328,7 +135,7 @@ void hash_sha2::sha256_end(uint8_t* hval, sha2_ctx<uint32_t>* ctx, size_t hlen)
     // NOTE: Little-endian words are corrected when used in sha_core
     ctx->wbuf[14] = ctx->count[1];
     ctx->wbuf[15] = ctx->count[0];
-    sha_core<uint32_t, 64, k256>(ctx);
+    m_sha256_core_method(ctx);
 
     // Extract the hash value as bytes in case of misalignment
     static const uint8_t shift_lut[4] = {24, 16, 8, 0};
@@ -360,7 +167,7 @@ void hash_sha2::sha512_end(uint8_t* hval, sha2_ctx<uint64_t>* ctx, size_t hlen)
         if (i < 120) {
             ctx->wbuf[15] = 0;
         }
-        sha_core<uint64_t, 80, k512>(ctx);
+        sha2_core_generic::core<uint64_t, 80, k512>(ctx);
         i = 0;
     }
     else {
@@ -375,7 +182,7 @@ void hash_sha2::sha512_end(uint8_t* hval, sha2_ctx<uint64_t>* ctx, size_t hlen)
     // NOTE: Little-endian words are corrected when used in sha_core
     ctx->wbuf[14] = ctx->count[1];
     ctx->wbuf[15] = ctx->count[0];
-    sha_core<uint64_t, 80, k512>(ctx);
+    sha2_core_generic::core<uint64_t, 80, k512>(ctx);
 
     // Extract the hash value as bytes in case of misalignment
     static const uint8_t shift_lut[8] = {56, 48, 40, 32, 24, 16, 8, 0};
@@ -390,6 +197,12 @@ void hash_sha2::sha512_end(uint8_t* hval, sha2_ctx<uint64_t>* ctx, size_t hlen)
 
 hash_sha2::hash_sha2()
 {
+    if (sha2_core_ni::has_sha_ni()) {
+        m_sha256_core_method = sha2_core_ni::core;
+    }
+    else {
+        m_sha256_core_method = sha2_core_generic::core<uint32_t, 64, k256>;
+    }
 }
 
 hash_sha2::~hash_sha2()

--- a/src/crypto/hash_sha2.hpp
+++ b/src/crypto/hash_sha2.hpp
@@ -11,6 +11,7 @@
 
 #include "crypto/hash.hpp"
 #include <limits>
+#include "crypto/sha2.hpp"
 
 
 namespace phantom {
@@ -32,20 +33,6 @@ namespace crypto {
 
 /**
  * @ingroup hashing
- * @brief SHA-2 context
- * 
- * @tparam T A 32-bit (SHA2-224/256) or 64-bit (SHA2-384/512) unsigned integer type
- */
-template<typename T>
-struct sha2_ctx
-{
-    T count[2];
-    T hash[8];
-    T wbuf[16];
-};
-
-/**
- * @ingroup hashing
  * @brief NIST SHA-2.
  * Derived from the hash base class, supports SHA-224, SHA-256, SHA-384 and SHA-512.
  */
@@ -62,107 +49,8 @@ public:
     void final(uint8_t *data) override;
 
 private:
-    template<typename T>
-    static inline T rotr(T x, size_t n) { return (x >> n) | (x << (std::numeric_limits<T>::digits - n)); }
-
-    template<typename T>
-    static inline T ch(T x, T y, T z) { return z ^ (x & (y ^ z)); }
-    template<typename T>
-    static inline T maj(T x, T y, T z) { return (x & y) | (z & (x ^ y)); }
-
     static inline void byteswap(uint32_t* p, size_t n);
     static inline void byteswap(uint64_t* p, size_t n);
-
-    static inline uint32_t s_0(uint32_t x) { return (rotr(x,  2) ^ rotr(x, 13) ^ rotr(x, 22)); }
-    static inline uint32_t s_1(uint32_t x) { return (rotr(x,  6) ^ rotr(x, 11) ^ rotr(x, 25)); }
-    static inline uint32_t g_0(uint32_t x) { return (rotr(x,  7) ^ rotr(x, 18) ^ (x >>  3)); }
-    static inline uint32_t g_1(uint32_t x) { return (rotr(x, 17) ^ rotr(x, 19) ^ (x >> 10)); }
-
-    static inline uint64_t s_0(uint64_t x) { return (rotr(x, 28) ^ rotr(x, 34) ^ rotr(x, 39)); }
-    static inline uint64_t s_1(uint64_t x) { return (rotr(x, 14) ^ rotr(x, 18) ^ rotr(x, 41)); }
-    static inline uint64_t g_0(uint64_t x) { return (rotr(x,  1) ^ rotr(x,  8) ^ (x >>  7)); }
-    static inline uint64_t g_1(uint64_t x) { return (rotr(x, 19) ^ rotr(x, 61) ^ (x >>  6)); }
-
-    template<typename T>
-    static inline T hf(size_t i, T* p) {
-        return p[i & 15] += g_1(p[(i + 14) & 15]) + p[(i + 9) & 15] + g_0(p[(i + 1) & 15]);
-    }
-
-    template<typename T, const T* k, size_t i>
-    static inline void v_cycle_0(T* p, T* v)
-    {
-        v[(7 - i) & 7] += p[i] + k[i] + s_1(v[(4 - i) & 7]) + ch(v[(4 - i) & 7], v[(5 - i) & 7], v[(6 - i) & 7]);
-        v[(3 - i) & 7] += v[(7 - i) & 7];
-        v[(7 - i) & 7] += s_0(v[(0 - i) & 7])+ maj(v[(0 - i) & 7], v[(1 - i) & 7], v[(2 - i) & 7]);
-    }
-
-    template<typename T, const T* k, size_t i>
-    static inline void v_cycle(size_t j, T* p, T* v)
-    {
-        v[(7 - i) & 7] += hf(i, p) + k[i+j] + s_1(v[(4 - i) & 7]) + ch(v[(4 - i) & 7], v[(5 - i) & 7], v[(6 - i) & 7]);
-        v[(3 - i) & 7] += v[(7 - i) & 7];
-        v[(7 - i) & 7] += s_0(v[(0 - i) & 7])+ maj(v[(0 - i) & 7], v[(1 - i) & 7], v[(2 - i) & 7]);
-    }
-
-    template<typename T, size_t M, const T* k>
-    static inline void sha_core(sha2_ctx<T>* ctx)
-    {
-        T *p = ctx->wbuf;
-        alignas(DEFAULT_MEM_ALIGNMENT) T v[8];
-
-        v[0] = ctx->hash[0];
-        v[1] = ctx->hash[1];
-        v[2] = ctx->hash[2];
-        v[3] = ctx->hash[3];
-        v[4] = ctx->hash[4];
-        v[5] = ctx->hash[5];
-        v[6] = ctx->hash[6];
-        v[7] = ctx->hash[7];
-
-        v_cycle_0<T, k,  0>(p, v);
-        v_cycle_0<T, k,  1>(p, v);
-        v_cycle_0<T, k,  2>(p, v);
-        v_cycle_0<T, k,  3>(p, v);
-        v_cycle_0<T, k,  4>(p, v);
-        v_cycle_0<T, k,  5>(p, v);
-        v_cycle_0<T, k,  6>(p, v);
-        v_cycle_0<T, k,  7>(p, v);
-        v_cycle_0<T, k,  8>(p, v);
-        v_cycle_0<T, k,  9>(p, v);
-        v_cycle_0<T, k, 10>(p, v);
-        v_cycle_0<T, k, 11>(p, v);
-        v_cycle_0<T, k, 12>(p, v);
-        v_cycle_0<T, k, 13>(p, v);
-        v_cycle_0<T, k, 14>(p, v);
-        v_cycle_0<T, k, 15>(p, v);
-        for (size_t i=16; i < M; i+=16) {
-            v_cycle<T, k,  0>(i, p, v);
-            v_cycle<T, k,  1>(i, p, v);
-            v_cycle<T, k,  2>(i, p, v);
-            v_cycle<T, k,  3>(i, p, v);
-            v_cycle<T, k,  4>(i, p, v);
-            v_cycle<T, k,  5>(i, p, v);
-            v_cycle<T, k,  6>(i, p, v);
-            v_cycle<T, k,  7>(i, p, v);
-            v_cycle<T, k,  8>(i, p, v);
-            v_cycle<T, k,  9>(i, p, v);
-            v_cycle<T, k, 10>(i, p, v);
-            v_cycle<T, k, 11>(i, p, v);
-            v_cycle<T, k, 12>(i, p, v);
-            v_cycle<T, k, 13>(i, p, v);
-            v_cycle<T, k, 14>(i, p, v);
-            v_cycle<T, k, 15>(i, p, v);
-        }
-
-        ctx->hash[0] += v[0];
-        ctx->hash[1] += v[1];
-        ctx->hash[2] += v[2];
-        ctx->hash[3] += v[3];
-        ctx->hash[4] += v[4];
-        ctx->hash[5] += v[5];
-        ctx->hash[6] += v[6];
-        ctx->hash[7] += v[7];
-    }
 
     void sha256_hash(const uint8_t* data, size_t len, sha2_ctx<uint32_t>* ctx);
     void sha512_hash(const uint8_t* data, size_t len, sha2_ctx<uint64_t>* ctx);
@@ -175,8 +63,8 @@ private:
     } m_ctx;
     size_t m_sha2_len;
 
-    alignas(DEFAULT_MEM_ALIGNMENT) static const uint32_t k256[64];
-    alignas(DEFAULT_MEM_ALIGNMENT) static const uint64_t k512[80];
+    using sha256_core_method = void (*)(sha2_ctx<uint32_t>*);
+    sha256_core_method m_sha256_core_method;
 };
 
 }  // namespace crypto

--- a/src/crypto/sha2.hpp
+++ b/src/crypto/sha2.hpp
@@ -1,0 +1,228 @@
+/*****************************************************************************
+ * Copyright (C) Neil Smyth 2022                                             *
+ *                                                                           *
+ * This file is part of phantom.                                             *
+ *                                                                           *
+ * This file is subject to the terms and conditions defined in the file      *
+ * 'LICENSE', which is part of this source code package.                     *
+ *****************************************************************************/
+
+#pragma once
+
+
+namespace phantom {
+namespace crypto {
+
+
+/**
+ * @ingroup hashing
+ * @brief SHA-2 context
+ * 
+ * @tparam T A 32-bit (SHA2-224/256) or 64-bit (SHA2-384/512) unsigned integer type
+ */
+template<typename T>
+struct sha2_ctx
+{
+    T count[2];
+    T hash[8];
+    T wbuf[16];
+};
+
+
+alignas(DEFAULT_MEM_ALIGNMENT) const uint32_t k256[64] = {
+    UINT32_C(0x428a2f98),
+    UINT32_C(0x71374491),
+    UINT32_C(0xb5c0fbcf),
+    UINT32_C(0xe9b5dba5),
+    UINT32_C(0x3956c25b),
+    UINT32_C(0x59f111f1),
+    UINT32_C(0x923f82a4),
+    UINT32_C(0xab1c5ed5),
+    UINT32_C(0xd807aa98),
+    UINT32_C(0x12835b01),
+    UINT32_C(0x243185be),
+    UINT32_C(0x550c7dc3),
+    UINT32_C(0x72be5d74),
+    UINT32_C(0x80deb1fe),
+    UINT32_C(0x9bdc06a7),
+    UINT32_C(0xc19bf174),
+    UINT32_C(0xe49b69c1),
+    UINT32_C(0xefbe4786),
+    UINT32_C(0x0fc19dc6),
+    UINT32_C(0x240ca1cc),
+    UINT32_C(0x2de92c6f),
+    UINT32_C(0x4a7484aa),
+    UINT32_C(0x5cb0a9dc),
+    UINT32_C(0x76f988da),
+    UINT32_C(0x983e5152),
+    UINT32_C(0xa831c66d),
+    UINT32_C(0xb00327c8),
+    UINT32_C(0xbf597fc7),
+    UINT32_C(0xc6e00bf3),
+    UINT32_C(0xd5a79147),
+    UINT32_C(0x06ca6351),
+    UINT32_C(0x14292967),
+    UINT32_C(0x27b70a85),
+    UINT32_C(0x2e1b2138),
+    UINT32_C(0x4d2c6dfc),
+    UINT32_C(0x53380d13),
+    UINT32_C(0x650a7354),
+    UINT32_C(0x766a0abb),
+    UINT32_C(0x81c2c92e),
+    UINT32_C(0x92722c85),
+    UINT32_C(0xa2bfe8a1),
+    UINT32_C(0xa81a664b),
+    UINT32_C(0xc24b8b70),
+    UINT32_C(0xc76c51a3),
+    UINT32_C(0xd192e819),
+    UINT32_C(0xd6990624),
+    UINT32_C(0xf40e3585),
+    UINT32_C(0x106aa070),
+    UINT32_C(0x19a4c116),
+    UINT32_C(0x1e376c08),
+    UINT32_C(0x2748774c),
+    UINT32_C(0x34b0bcb5),
+    UINT32_C(0x391c0cb3),
+    UINT32_C(0x4ed8aa4a),
+    UINT32_C(0x5b9cca4f),
+    UINT32_C(0x682e6ff3),
+    UINT32_C(0x748f82ee),
+    UINT32_C(0x78a5636f),
+    UINT32_C(0x84c87814),
+    UINT32_C(0x8cc70208),
+    UINT32_C(0x90befffa),
+    UINT32_C(0xa4506ceb),
+    UINT32_C(0xbef9a3f7),
+    UINT32_C(0xc67178f2),
+};
+
+alignas(DEFAULT_MEM_ALIGNMENT) const uint64_t k512[80] = {
+    UINT64_C(0x428a2f98d728ae22),
+    UINT64_C(0x7137449123ef65cd),
+    UINT64_C(0xb5c0fbcfec4d3b2f),
+    UINT64_C(0xe9b5dba58189dbbc),
+    UINT64_C(0x3956c25bf348b538),
+    UINT64_C(0x59f111f1b605d019),
+    UINT64_C(0x923f82a4af194f9b),
+    UINT64_C(0xab1c5ed5da6d8118),
+    UINT64_C(0xd807aa98a3030242),
+    UINT64_C(0x12835b0145706fbe),
+    UINT64_C(0x243185be4ee4b28c),
+    UINT64_C(0x550c7dc3d5ffb4e2),
+    UINT64_C(0x72be5d74f27b896f),
+    UINT64_C(0x80deb1fe3b1696b1),
+    UINT64_C(0x9bdc06a725c71235),
+    UINT64_C(0xc19bf174cf692694),
+    UINT64_C(0xe49b69c19ef14ad2),
+    UINT64_C(0xefbe4786384f25e3),
+    UINT64_C(0x0fc19dc68b8cd5b5),
+    UINT64_C(0x240ca1cc77ac9c65),
+    UINT64_C(0x2de92c6f592b0275),
+    UINT64_C(0x4a7484aa6ea6e483),
+    UINT64_C(0x5cb0a9dcbd41fbd4),
+    UINT64_C(0x76f988da831153b5),
+    UINT64_C(0x983e5152ee66dfab),
+    UINT64_C(0xa831c66d2db43210),
+    UINT64_C(0xb00327c898fb213f),
+    UINT64_C(0xbf597fc7beef0ee4),
+    UINT64_C(0xc6e00bf33da88fc2),
+    UINT64_C(0xd5a79147930aa725),
+    UINT64_C(0x06ca6351e003826f),
+    UINT64_C(0x142929670a0e6e70),
+    UINT64_C(0x27b70a8546d22ffc),
+    UINT64_C(0x2e1b21385c26c926),
+    UINT64_C(0x4d2c6dfc5ac42aed),
+    UINT64_C(0x53380d139d95b3df),
+    UINT64_C(0x650a73548baf63de),
+    UINT64_C(0x766a0abb3c77b2a8),
+    UINT64_C(0x81c2c92e47edaee6),
+    UINT64_C(0x92722c851482353b),
+    UINT64_C(0xa2bfe8a14cf10364),
+    UINT64_C(0xa81a664bbc423001),
+    UINT64_C(0xc24b8b70d0f89791),
+    UINT64_C(0xc76c51a30654be30),
+    UINT64_C(0xd192e819d6ef5218),
+    UINT64_C(0xd69906245565a910),
+    UINT64_C(0xf40e35855771202a),
+    UINT64_C(0x106aa07032bbd1b8),
+    UINT64_C(0x19a4c116b8d2d0c8),
+    UINT64_C(0x1e376c085141ab53),
+    UINT64_C(0x2748774cdf8eeb99),
+    UINT64_C(0x34b0bcb5e19b48a8),
+    UINT64_C(0x391c0cb3c5c95a63),
+    UINT64_C(0x4ed8aa4ae3418acb),
+    UINT64_C(0x5b9cca4f7763e373),
+    UINT64_C(0x682e6ff3d6b2b8a3),
+    UINT64_C(0x748f82ee5defb2fc),
+    UINT64_C(0x78a5636f43172f60),
+    UINT64_C(0x84c87814a1f0ab72),
+    UINT64_C(0x8cc702081a6439ec),
+    UINT64_C(0x90befffa23631e28),
+    UINT64_C(0xa4506cebde82bde9),
+    UINT64_C(0xbef9a3f7b2c67915),
+    UINT64_C(0xc67178f2e372532b),
+    UINT64_C(0xca273eceea26619c),
+    UINT64_C(0xd186b8c721c0c207),
+    UINT64_C(0xeada7dd6cde0eb1e),
+    UINT64_C(0xf57d4f7fee6ed178),
+    UINT64_C(0x06f067aa72176fba),
+    UINT64_C(0x0a637dc5a2c898a6),
+    UINT64_C(0x113f9804bef90dae),
+    UINT64_C(0x1b710b35131c471b),
+    UINT64_C(0x28db77f523047d84),
+    UINT64_C(0x32caab7b40c72493),
+    UINT64_C(0x3c9ebe0a15c9bebc),
+    UINT64_C(0x431d67c49c100d4c),
+    UINT64_C(0x4cc5d4becb3e42b6),
+    UINT64_C(0x597f299cfc657e2a),
+    UINT64_C(0x5fcb6fab3ad6faec),
+    UINT64_C(0x6c44198c4a475817)
+};
+
+alignas(DEFAULT_MEM_ALIGNMENT) const uint64_t i512[8] = {
+    UINT64_C(0x6a09e667f3bcc908),
+    UINT64_C(0xbb67ae8584caa73b),
+    UINT64_C(0x3c6ef372fe94f82b),
+    UINT64_C(0xa54ff53a5f1d36f1),
+    UINT64_C(0x510e527fade682d1),
+    UINT64_C(0x9b05688c2b3e6c1f),
+    UINT64_C(0x1f83d9abfb41bd6b),
+    UINT64_C(0x5be0cd19137e2179)
+};
+
+alignas(DEFAULT_MEM_ALIGNMENT) const uint64_t i384[8] = {
+    UINT64_C(0xcbbb9d5dc1059ed8),
+    UINT64_C(0x629a292a367cd507),
+    UINT64_C(0x9159015a3070dd17),
+    UINT64_C(0x152fecd8f70e5939),
+    UINT64_C(0x67332667ffc00b31),
+    UINT64_C(0x8eb44a8768581511),
+    UINT64_C(0xdb0c2e0d64f98fa7),
+    UINT64_C(0x47b5481dbefa4fa4)
+};
+
+alignas(DEFAULT_MEM_ALIGNMENT) const uint32_t i256[8] = {
+    UINT32_C(0x6a09e667),
+    UINT32_C(0xbb67ae85),
+    UINT32_C(0x3c6ef372),
+    UINT32_C(0xa54ff53a),
+    UINT32_C(0x510e527f),
+    UINT32_C(0x9b05688c),
+    UINT32_C(0x1f83d9ab),
+    UINT32_C(0x5be0cd19)
+};
+
+alignas(DEFAULT_MEM_ALIGNMENT) const uint32_t i224[8] = {
+    UINT32_C(0xc1059ed8),
+    UINT32_C(0x367cd507),
+    UINT32_C(0x3070dd17),
+    UINT32_C(0xf70e5939),
+    UINT32_C(0xffc00b31),
+    UINT32_C(0x68581511),
+    UINT32_C(0x64f98fa7),
+    UINT32_C(0xbefa4fa4)
+};
+
+
+}  // namespace crypto
+}  // namespace phantom

--- a/src/crypto/sha2_core_generic.hpp
+++ b/src/crypto/sha2_core_generic.hpp
@@ -1,0 +1,143 @@
+/*****************************************************************************
+ * Copyright (C) Neil Smyth 2020                                             *
+ *                                                                           *
+ * This file is part of phantom.                                             *
+ *                                                                           *
+ * This file is subject to the terms and conditions defined in the file      *
+ * 'LICENSE', which is part of this source code package.                     *
+ *****************************************************************************/
+
+#pragma once
+
+#include "crypto/sha2.hpp"
+#include "crypto/hash.hpp"
+
+
+namespace phantom {
+namespace crypto {
+
+#define SHA224_DIGEST_SIZE      28
+#define SHA224_BLOCK_SIZE       64
+#define SHA256_DIGEST_SIZE      32
+#define SHA256_BLOCK_SIZE       64
+#define SHA384_DIGEST_SIZE      48
+#define SHA384_BLOCK_SIZE       128
+#define SHA512_DIGEST_SIZE      64
+#define SHA512_BLOCK_SIZE       128
+#define SHA2_MAX_DIGEST_SIZE    SHA512_DIGEST_SIZE
+
+#define SHA256_MASK             (SHA256_BLOCK_SIZE - 1)
+#define SHA512_MASK             (SHA512_BLOCK_SIZE - 1)
+
+
+/**
+ * @ingroup hashing
+ * @brief NIST SHA-2.
+ * Derived from the hash base class, supports SHA-224, SHA-256, SHA-384 and SHA-512.
+ */
+class sha2_core_generic : public hash
+{
+private:
+    template<typename T>
+    static inline T rotr(T x, size_t n) { return (x >> n) | (x << (std::numeric_limits<T>::digits - n)); }
+
+    template<typename T>
+    static inline T ch(T x, T y, T z) { return z ^ (x & (y ^ z)); }
+    template<typename T>
+    static inline T maj(T x, T y, T z) { return (x & y) | (z & (x ^ y)); }
+
+    static inline uint32_t s_0(uint32_t x) { return (rotr(x,  2) ^ rotr(x, 13) ^ rotr(x, 22)); }
+    static inline uint32_t s_1(uint32_t x) { return (rotr(x,  6) ^ rotr(x, 11) ^ rotr(x, 25)); }
+    static inline uint32_t g_0(uint32_t x) { return (rotr(x,  7) ^ rotr(x, 18) ^ (x >>  3)); }
+    static inline uint32_t g_1(uint32_t x) { return (rotr(x, 17) ^ rotr(x, 19) ^ (x >> 10)); }
+
+    static inline uint64_t s_0(uint64_t x) { return (rotr(x, 28) ^ rotr(x, 34) ^ rotr(x, 39)); }
+    static inline uint64_t s_1(uint64_t x) { return (rotr(x, 14) ^ rotr(x, 18) ^ rotr(x, 41)); }
+    static inline uint64_t g_0(uint64_t x) { return (rotr(x,  1) ^ rotr(x,  8) ^ (x >>  7)); }
+    static inline uint64_t g_1(uint64_t x) { return (rotr(x, 19) ^ rotr(x, 61) ^ (x >>  6)); }
+
+    template<typename T>
+    static inline T hf(size_t i, T* p) {
+        return p[i & 15] += g_1(p[(i + 14) & 15]) + p[(i + 9) & 15] + g_0(p[(i + 1) & 15]);
+    }
+
+    template<typename T, const T* k, size_t i>
+    static inline void v_cycle_0(T* p, T* v)
+    {
+        v[(7 - i) & 7] += p[i] + k[i] + s_1(v[(4 - i) & 7]) + ch(v[(4 - i) & 7], v[(5 - i) & 7], v[(6 - i) & 7]);
+        v[(3 - i) & 7] += v[(7 - i) & 7];
+        v[(7 - i) & 7] += s_0(v[(0 - i) & 7])+ maj(v[(0 - i) & 7], v[(1 - i) & 7], v[(2 - i) & 7]);
+    }
+
+    template<typename T, const T* k, size_t i>
+    static inline void v_cycle(size_t j, T* p, T* v)
+    {
+        v[(7 - i) & 7] += hf(i, p) + k[i+j] + s_1(v[(4 - i) & 7]) + ch(v[(4 - i) & 7], v[(5 - i) & 7], v[(6 - i) & 7]);
+        v[(3 - i) & 7] += v[(7 - i) & 7];
+        v[(7 - i) & 7] += s_0(v[(0 - i) & 7])+ maj(v[(0 - i) & 7], v[(1 - i) & 7], v[(2 - i) & 7]);
+    }
+
+public:
+    template<typename T, size_t M, const T* k>
+    static inline void core(sha2_ctx<T>* ctx)
+    {
+        T *p = ctx->wbuf;
+        alignas(DEFAULT_MEM_ALIGNMENT) T v[8];
+
+        v[0] = ctx->hash[0];
+        v[1] = ctx->hash[1];
+        v[2] = ctx->hash[2];
+        v[3] = ctx->hash[3];
+        v[4] = ctx->hash[4];
+        v[5] = ctx->hash[5];
+        v[6] = ctx->hash[6];
+        v[7] = ctx->hash[7];
+
+        v_cycle_0<T, k,  0>(p, v);
+        v_cycle_0<T, k,  1>(p, v);
+        v_cycle_0<T, k,  2>(p, v);
+        v_cycle_0<T, k,  3>(p, v);
+        v_cycle_0<T, k,  4>(p, v);
+        v_cycle_0<T, k,  5>(p, v);
+        v_cycle_0<T, k,  6>(p, v);
+        v_cycle_0<T, k,  7>(p, v);
+        v_cycle_0<T, k,  8>(p, v);
+        v_cycle_0<T, k,  9>(p, v);
+        v_cycle_0<T, k, 10>(p, v);
+        v_cycle_0<T, k, 11>(p, v);
+        v_cycle_0<T, k, 12>(p, v);
+        v_cycle_0<T, k, 13>(p, v);
+        v_cycle_0<T, k, 14>(p, v);
+        v_cycle_0<T, k, 15>(p, v);
+        for (size_t i=16; i < M; i+=16) {
+            v_cycle<T, k,  0>(i, p, v);
+            v_cycle<T, k,  1>(i, p, v);
+            v_cycle<T, k,  2>(i, p, v);
+            v_cycle<T, k,  3>(i, p, v);
+            v_cycle<T, k,  4>(i, p, v);
+            v_cycle<T, k,  5>(i, p, v);
+            v_cycle<T, k,  6>(i, p, v);
+            v_cycle<T, k,  7>(i, p, v);
+            v_cycle<T, k,  8>(i, p, v);
+            v_cycle<T, k,  9>(i, p, v);
+            v_cycle<T, k, 10>(i, p, v);
+            v_cycle<T, k, 11>(i, p, v);
+            v_cycle<T, k, 12>(i, p, v);
+            v_cycle<T, k, 13>(i, p, v);
+            v_cycle<T, k, 14>(i, p, v);
+            v_cycle<T, k, 15>(i, p, v);
+        }
+
+        ctx->hash[0] += v[0];
+        ctx->hash[1] += v[1];
+        ctx->hash[2] += v[2];
+        ctx->hash[3] += v[3];
+        ctx->hash[4] += v[4];
+        ctx->hash[5] += v[5];
+        ctx->hash[6] += v[6];
+        ctx->hash[7] += v[7];
+    }
+};
+
+}  // namespace crypto
+}  // namespace phantom

--- a/src/crypto/sha2_core_ni.hpp
+++ b/src/crypto/sha2_core_ni.hpp
@@ -1,0 +1,222 @@
+/*****************************************************************************
+ * Copyright (C) Neil Smyth 2022                                             *
+ *                                                                           *
+ * This file is part of phantom.                                             *
+ *                                                                           *
+ * This file is subject to the terms and conditions defined in the file      *
+ * 'LICENSE', which is part of this source code package.                     *
+ *****************************************************************************/
+
+#pragma once
+
+#include "crypto/sha2.hpp"
+#include "crypto/hash.hpp"
+
+#if defined(__x86_64__) && __has_include("cpuid.h")
+#include <cpuid.h>
+#endif
+
+#if defined(__GNUG__)
+# include <stdint.h>
+# include <x86intrin.h>
+
+// Ensure that we enable support for SHA-NI
+#pragma GCC target("sse4.1")
+#pragma GCC target("sha")
+
+#endif
+
+
+namespace phantom {
+namespace crypto {
+
+
+class sha2_core_ni
+{
+private:
+    /**
+     * @brief Updates the state variables A, B, C, ..., H for 4 rounds
+     */
+    static void update_state(int round, __m128i &msg, __m128i &ABEF, __m128i &CDGH)
+    {
+        const __m128i *k_round_vec = reinterpret_cast<const __m128i*>(&k256[round]);
+        msg  = _mm_add_epi32(msg, *k_round_vec);        // Add the K constants to the working buffer
+        CDGH = _mm_sha256rnds2_epu32(CDGH, ABEF, msg);  // 2 rounds using SHA-NI
+        msg  = _mm_shuffle_epi32(msg, 0x0E);            // Move words 2, 3 to positions 0, 1
+        ABEF = _mm_sha256rnds2_epu32(ABEF, CDGH, msg);  // 2 rounds using SHA-NI
+    }
+
+    /**
+     * @brief Helper method for rounds 16 - 51 to update the message schedule
+     */
+    static void update_message(__m128i msg_0, __m128i &msg_1, __m128i &msg_3, __m128i &temp)
+    {
+        temp  = _mm_alignr_epi8(msg_0, msg_3, 4);
+        msg_1 = _mm_add_epi32(msg_1, temp);
+        msg_1 = _mm_sha256msg2_epu32(msg_1, msg_0);
+        msg_3 = _mm_sha256msg1_epu32(msg_3, msg_0);
+    }
+
+public:
+    /**
+     * @brief  Method indicates if SHA-NI is available
+     */
+    static bool has_sha_ni()
+    {
+#if defined(__x86_64__) && __has_include("cpuid.h")
+        // Only 64-bit Intel and AMD CPU's support SHA-NI
+        static int32_t test = -1;
+        if (test < 0) {
+            uint32_t a, b, c, d;
+            if (!__get_cpuid(1, &a, &b, &c, &d)) {
+                test = 0;
+            }
+            else {
+                if (a < 7) {
+                    test = 0;
+                }
+                else {
+                    __get_cpuid_count(7, 0, &a, &b, &c, &d);
+                    test = b & (1 << 29);
+                }
+            }
+        }
+        return test != 0;
+#else
+        return false;
+#endif
+    }
+
+    /**
+     * @brief SHA2 coreimplementationusing SHA NI intrinsics
+     */
+    static void core(sha2_ctx<uint32_t>* ctx)
+    {
+        // Load the state and reorder
+        __m128i DCBA = _mm_loadu_si128(reinterpret_cast<__m128i*>(&ctx->hash[0]));  // (D, C, B, A)
+        __m128i HGFE = _mm_loadu_si128(reinterpret_cast<__m128i*>(&ctx->hash[4]));  // (H, G, F, E)
+        __m128i FEBA = _mm_unpacklo_epi64(DCBA, HGFE);                              // (F, E, B, A)
+        __m128i HGDC = _mm_unpackhi_epi64(DCBA, HGFE);                              // (H, G, D, C)
+        __m128i ABEF = _mm_shuffle_epi32(FEBA, 0x1B);                               // (A, B, E, F)
+        __m128i CDGH = _mm_shuffle_epi32(HGDC, 0x1B);                               // (C, D, G, H)
+
+        // Create a pointer to the working buffer
+        __m128i *data = reinterpret_cast<__m128i*>(ctx->wbuf);
+
+        // Save the current state for update later
+        __m128i ABEF_start = ABEF;
+        __m128i CDGH_start = CDGH;
+
+        // Temporary state
+        __m128i tmp;
+
+        // Accumulators for each round
+        __m128i msg_0, msg_1, msg_2, msg_3;
+
+        // Rounds 0 - 3
+        tmp   = _mm_loadu_si128(data);                  // Load 4 32-bit words
+        msg_0 = tmp;                                    // msg_0 = ( W_3 = M3, W_2 = M_2, W_1 = M_1, W_0 = M_0 )
+        update_state(0, tmp, ABEF, CDGH);
+
+        // Rounds 4 - 7
+        tmp   = _mm_loadu_si128(data + 1);              // Load next 4 32-bit words
+        msg_1 = tmp;                                    // msg_1 = ( W_7 = M_7, W_6 = M_6, W_5 = M_5, W_4 = M_4 )
+        update_state(4, tmp, ABEF, CDGH);
+        msg_0 = _mm_sha256msg1_epu32(msg_0, msg_1);     // msg_0 = ( X_19, X_18, X_17, X_16 ) =
+                                                        // ( W_3 + \sigma_0(W_4), ..., W_0 + \sigma_0(W_1) )
+
+        // Rounds 8 - 11
+        tmp   = _mm_loadu_si128(data + 2);              // Load next 4 32-bit words
+        msg_2 = tmp;                                    // msg_2 = ( W_11 = M_11, W_10 = M_10, W_9 = M_9, W_8 = M_8 )
+        update_state(8, tmp, ABEF, CDGH);
+        msg_1 = _mm_sha256msg1_epu32(msg_1, msg_2);     // msg_1 = ( X_23, X_22, X_21, X_20 )
+
+        // Rounds 12 - 15
+        tmp   = _mm_loadu_si128(data + 3);              // Load next 4 32-bit words
+        msg_3 = tmp;                                    // msg_3 = ( W_15 = M_15, W_14 = M_14, W_13 = M_13, W_12 = M_12 )
+        update_state(12, tmp, ABEF, CDGH);
+
+        // Update msg_0 using msg_2 before it's modified
+        tmp   = _mm_alignr_epi8(msg_3, msg_2, 4);       // tmp   = ( W_12, W_11, W_10, W_9 )
+        msg_0 = _mm_add_epi32(msg_0, tmp);              // msg_0 = msg_0 + ( W_12, W_11, W_10, W_9 )
+        msg_0 = _mm_sha256msg2_epu32(msg_0, msg_3);     // msg_0 = ( X_19 + W_12 + \sigma_1(W_17)], ..., X_16 + W_9 + \sigma_1(W_14)] )
+        msg_2 = _mm_sha256msg1_epu32(msg_2, msg_3);     // msg_2 = ( X_27, X_26, X_25, X_24 )
+
+        // Rounds 16 - 19
+        tmp   = msg_0;
+        update_state(16, tmp, ABEF, CDGH);
+        update_message(msg_0, msg_1, msg_3, tmp);
+
+        // Rounds 20 - 23
+        tmp   = msg_1;
+        update_state(20, tmp, ABEF, CDGH);
+        update_message(msg_1, msg_2, msg_0, tmp);
+
+        // Rounds 24 - 27
+        tmp   = msg_2;
+        update_state(24, tmp, ABEF, CDGH);
+        update_message(msg_2, msg_3, msg_1, tmp);
+
+        // Rounds 28 - 31
+        tmp   = msg_3;
+        update_state(28, tmp, ABEF, CDGH);
+        update_message(msg_3, msg_0, msg_2, tmp);
+
+        // Rounds 32 - 35
+        tmp   = msg_0;
+        update_state(32, tmp, ABEF, CDGH);
+        update_message(msg_0, msg_1, msg_3, tmp);
+
+        // Rounds 36 - 39
+        tmp   = msg_1;
+        update_state(36, tmp, ABEF, CDGH);
+        update_message(msg_1, msg_2, msg_0, tmp);
+
+        // Rounds 40 - 43
+        tmp   = msg_2;
+        update_state(40, tmp, ABEF, CDGH);
+        update_message(msg_2, msg_3, msg_1, tmp);
+
+        // Rounds 44 - 47
+        tmp   = msg_3;
+        update_state(44, tmp, ABEF, CDGH);
+        update_message(msg_3, msg_0, msg_2, tmp);
+
+        // Rounds 48 - 51
+        tmp   = msg_0;
+        update_state(48, tmp, ABEF, CDGH);
+        update_message(msg_0, msg_1, msg_3, tmp);
+
+        // Rounds 52 - 55
+        tmp   = msg_1;                                  // ( W_55, W_54, W_53, W_52 )
+        update_state(52, tmp, ABEF, CDGH);
+        tmp   = _mm_alignr_epi8(msg_1, msg_0, 4);       // tmp = ( W_52, W_51, W_50, W_49 )
+        msg_2 = _mm_add_epi32(msg_2, tmp);              // msg_2 = msg_2 + ( W_52, W_51, W_50, W_49 )
+        msg_2 = _mm_sha256msg2_epu32( msg_2, msg_1);    // Calculate ( W_59, W_58, W_57, W_56 )
+
+        // Rounds 56 - 59
+        tmp   = msg_2;                                  // ( W_59, W_58, W_57, W_56 )
+        update_state(56, tmp, ABEF, CDGH);
+        tmp   = _mm_alignr_epi8(msg_2, msg_1, 4);       // tmp = ( W_56, W_55, W_54, W_53 )
+        msg_3 = _mm_add_epi32(msg_3, tmp);              // msg_3 = msg_3 + ( W_56, W_55, W_54, W_53 )
+        msg_3 = _mm_sha256msg2_epu32(msg_3, msg_2);     // Calculate ( W_63, W_62, W_61, W_60 )
+
+        // Rounds 60 - 63
+        update_state(60, msg_3, ABEF, CDGH);
+
+        // Update the existing state by addition
+        ABEF = _mm_add_epi32(ABEF, ABEF_start);
+        CDGH = _mm_add_epi32(CDGH, CDGH_start);
+
+        // Unpack the state registers and store them
+        FEBA = _mm_shuffle_epi32(ABEF, 0x1B);
+        HGDC = _mm_shuffle_epi32(CDGH, 0x1B);
+        DCBA = _mm_unpacklo_epi64(FEBA, HGDC);                              // (D, C, B, A)
+        HGFE = _mm_unpackhi_epi64(FEBA, HGDC);                              // (H, G, F, E)
+        _mm_storeu_si128(reinterpret_cast<__m128i*>(&ctx->hash[0]), DCBA);  // (D, C, B, A)
+        _mm_storeu_si128(reinterpret_cast<__m128i*>(&ctx->hash[4]), HGFE);  // (H, G, F, E)
+    }
+};
+
+}  // namespace crypto
+}  // namespace phantom


### PR DESCRIPTION
Similar to AES-NI, if compiled on x86_64 and the CPU indicates the SHA-NI instruction set is available hardware acceleration will now be enabled - otherwise the software implementation will be used.

Tests on a 2.4GHz AMD Epyc show peak performance of ~1200 MB/sec for SHA-224 and SHA-256 as opposed to ~160 MB/sec for software only, giving approx. 750% performance improvement.